### PR TITLE
セキュリティ強化: CSPヘッダー・写真検証・EXIF除去

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,65 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        // 全ページに適用
+        source: "/(.*)",
+        headers: [
+          {
+            // クリックジャッキング防止: 他サイトのiframeに埋め込まれることを防ぐ
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            // MIMEスニッフィング防止: ブラウザがContent-Typeを推測しない
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            // リファラー情報の制限: 外部サイトにURLのパス情報を送らない
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            // HTTPS強制: ブラウザにHTTPSのみの通信を強制（1年間）
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+          {
+            // 権限ポリシー: カメラ・マイク・位置情報等の使用を自サイトのみに制限
+            // camera は施術写真の撮影に必要なので self で許可
+            key: "Permissions-Policy",
+            value: "camera=(self), microphone=(), geolocation=(), interest-cohort=()",
+          },
+          {
+            // CSP: スクリプト・スタイル・画像等の読み込み元を制限
+            // XSS攻撃で外部スクリプトを注入されることを防ぐ
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              // Next.js は inline script / eval を使うため unsafe-inline, unsafe-eval が必要
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              // 画像: 自サイト + Supabase Storage (署名付きURL) + blob (プレビュー)
+              "img-src 'self' blob: data: https://*.supabase.co",
+              // フォント: 自サイトのみ
+              "font-src 'self'",
+              // API接続先: 自サイト + Supabase
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+              // フレーム埋め込み禁止
+              "frame-ancestors 'none'",
+              // フォーム送信先: 自サイトのみ
+              "form-action 'self'",
+              // base URI: 自サイトのみ
+              "base-uri 'self'",
+            ].join("; "),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "salon-karte-init",
+  "name": "salon-karte",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "salon-karte-init",
+      "name": "salon-karte",
       "version": "0.1.0",
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
@@ -23,7 +23,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.12",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1084,6 +1084,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
       "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.95.3",
         "@supabase/functions-js": "2.95.3",
@@ -1428,6 +1429,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1496,6 +1498,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1995,6 +1998,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2848,6 +2852,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3021,6 +3026,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5144,6 +5150,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5153,6 +5160,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5831,6 +5839,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5980,6 +5989,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.12",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -1,6 +1,104 @@
 import { createClient } from "./client";
 import type { PhotoEntry } from "@/components/records/photo-upload";
 
+// --- セキュリティ: 許可するファイルタイプとサイズ上限 ---
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+];
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB（スマホの高画質写真に対応）
+
+// ファイルの先頭バイトでマジックナンバーを検証（拡張子偽装を防止）
+const MAGIC_NUMBERS: { mime: string; bytes: number[] }[] = [
+  { mime: "image/jpeg", bytes: [0xff, 0xd8, 0xff] },
+  { mime: "image/png", bytes: [0x89, 0x50, 0x4e, 0x47] },
+  { mime: "image/webp", bytes: [0x52, 0x49, 0x46, 0x46] }, // RIFF
+  // HEIC/HEIF は ftyp ボックスで識別（オフセット4から）
+];
+
+async function validateFileType(file: File): Promise<boolean> {
+  // 1. MIMEタイプチェック
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return false;
+  }
+
+  // 2. マジックナンバーチェック（ファイル先頭バイトで実際の形式を検証）
+  try {
+    const buffer = await file.slice(0, 12).arrayBuffer();
+    const header = new Uint8Array(buffer);
+
+    // HEIC/HEIF: オフセット4から "ftyp" があるか
+    if (file.type === "image/heic" || file.type === "image/heif") {
+      const ftypStr = String.fromCharCode(...header.slice(4, 8));
+      return ftypStr === "ftyp";
+    }
+
+    // その他の画像: 先頭バイト照合
+    return MAGIC_NUMBERS.some(({ bytes }) =>
+      bytes.every((byte, i) => header[i] === byte)
+    );
+  } catch {
+    return false;
+  }
+}
+
+// EXIF情報を除去してプライバシーを保護（位置情報・デバイス情報の漏洩防止）
+async function stripExif(file: File): Promise<File> {
+  // JPEG のみ EXIF 除去を行う（PNG/WebPにはEXIFは通常含まれない）
+  if (file.type !== "image/jpeg") {
+    return file;
+  }
+
+  return new Promise((resolve) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+
+    img.onload = () => {
+      // Canvas に描画して EXIF を除去した新しい画像を生成
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        URL.revokeObjectURL(url);
+        resolve(file); // Canvas取得に失敗した場合は元ファイルを返す
+        return;
+      }
+
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            // EXIF除去済みの新しいFileオブジェクトを生成
+            const cleanFile = new File([blob], file.name, {
+              type: "image/jpeg",
+              lastModified: Date.now(),
+            });
+            resolve(cleanFile);
+          } else {
+            resolve(file);
+          }
+        },
+        "image/jpeg",
+        0.92 // 高画質を維持
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve(file); // 読み込みエラー時は元ファイルを返す
+    };
+
+    img.src = url;
+  });
+}
+
 export async function uploadPhotos(
   recordId: string,
   salonId: string,
@@ -10,14 +108,44 @@ export async function uploadPhotos(
   const errors: string[] = [];
 
   for (const photo of photos) {
-    const ext = photo.file.name.split(".").pop() || "jpg";
+    // セキュリティ検証1: ファイルサイズチェック
+    if (photo.file.size > MAX_FILE_SIZE) {
+      const sizeMB = Math.round(photo.file.size / 1024 / 1024);
+      errors.push(
+        `ファイルサイズが大きすぎます（${sizeMB}MB）。20MB以下の画像をお使いください。`
+      );
+      continue;
+    }
+
+    // セキュリティ検証2: ファイルタイプの検証（マジックナンバー検証含む）
+    const isValid = await validateFileType(photo.file);
+    if (!isValid) {
+      errors.push(
+        `対応していないファイル形式です。JPEG, PNG, WebP, HEIC形式の画像をお使いください。`
+      );
+      continue;
+    }
+
+    // セキュリティ処理: EXIF情報を除去（位置情報・デバイス情報の漏洩防止）
+    const cleanFile = await stripExif(photo.file);
+
+    // 安全な拡張子を MIME タイプから決定（拡張子偽装を防ぐ）
+    const mimeToExt: Record<string, string> = {
+      "image/jpeg": "jpg",
+      "image/png": "png",
+      "image/webp": "webp",
+      "image/heic": "heic",
+      "image/heif": "heif",
+    };
+    const ext = mimeToExt[cleanFile.type] || "jpg";
     const path = `${salonId}/${recordId}/${photo.type}_${Date.now()}.${ext}`;
 
     const { error: uploadError } = await supabase.storage
       .from("treatment-photos")
-      .upload(path, photo.file, {
+      .upload(path, cleanFile, {
         cacheControl: "3600",
         upsert: false,
+        contentType: cleanFile.type, // MIMEタイプを明示的に指定
       });
 
     if (uploadError) {
@@ -41,6 +169,8 @@ export async function uploadPhotos(
 
   return { errors };
 }
+
+export { MAX_FILE_SIZE, ALLOWED_MIME_TYPES };
 
 export async function getPhotoUrl(storagePath: string): Promise<string | null> {
   const supabase = createClient();


### PR DESCRIPTION
## Summary
- CSP/HSTS/X-Frame-Options等のセキュリティヘッダーを全ページに追加
- 写真アップロード時にマジックナンバー検証・サイズ制限(20MB)・EXIF除去を実装
- UIにファイル形式・サイズのバリデーションエラー表示を追加

## 背景
テスター提供前のセキュリティ強化。カルテは個人情報と施術写真（裸の画像含む）を扱うため、漏洩リスクを最小化。

## 変更ファイル
- `next.config.ts` - セキュリティヘッダー追加
- `src/lib/supabase/storage.ts` - ファイル検証・EXIF除去・サイズ制限
- `src/components/records/photo-upload.tsx` - クライアント側バリデーション・UIフィードバック

## Test plan
- [ ] ビルドが成功すること（確認済み ✅）
- [ ] JPEG写真アップロード時にEXIF情報が除去されること
- [ ] 20MB超のファイルがエラーメッセージで拒否されること
- [ ] 非画像ファイルがアップロードできないこと
- [ ] レスポンスヘッダーにCSP等が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)