### PR TITLE
fix: テスト検出の不具合4件を修正

### DIFF
--- a/src/app/(dashboard)/appointments/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/appointments/[id]/edit/page.tsx
@@ -221,10 +221,14 @@ export default function EditAppointmentPage() {
     }
 
     // Update junction table: delete old, insert new
-    await supabase
+    const { error: deleteError } = await supabase
       .from("appointment_menus")
       .delete()
       .eq("appointment_id", appointmentId);
+
+    if (deleteError) {
+      console.error("Junction delete error:", deleteError);
+    }
 
     if (selectedMenuIds.length > 0) {
       const junctionRows = selectedMenusList.map(({ id, menu, index }) => ({
@@ -236,7 +240,10 @@ export default function EditAppointmentPage() {
         sort_order: index,
       }));
 
-      await supabase.from("appointment_menus").insert(junctionRows);
+      const { error: junctionError } = await supabase.from("appointment_menus").insert(junctionRows);
+      if (junctionError) {
+        console.error("Junction insert error:", junctionError);
+      }
     }
 
     router.push("/appointments");

--- a/src/app/(dashboard)/appointments/new/page.tsx
+++ b/src/app/(dashboard)/appointments/new/page.tsx
@@ -215,7 +215,10 @@ function NewAppointmentForm() {
         sort_order: index,
       }));
 
-      await supabase.from("appointment_menus").insert(junctionRows);
+      const { error: junctionError } = await supabase.from("appointment_menus").insert(junctionRows);
+      if (junctionError) {
+        console.error("Junction insert error:", junctionError);
+      }
     }
 
     router.push("/appointments");

--- a/src/app/(dashboard)/guide/page.tsx
+++ b/src/app/(dashboard)/guide/page.tsx
@@ -133,7 +133,7 @@ export default function GuidePage() {
           <StepCard
             number={3}
             title="施術後：カルテを記入"
-            description="顧客詳細画面の「施術記録を追加」から、今日の施術内容を記録します。写真も一緒に保存できます。"
+            description="顧客詳細画面の「+ カルテ作成」から、今日の施術内容を記録します。写真も一緒に保存できます。"
             link="/customers"
             linkLabel="顧客を選んで記録する"
           />
@@ -500,7 +500,7 @@ export default function GuidePage() {
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-text-light">全部入り</span>
-                <span className="font-bold">月 5,480円</span>
+                <span className="font-bold">月 7,080円</span>
               </div>
             </div>
             <p className="text-xs text-text-light mt-3">

--- a/src/components/customers/course-ticket-section.tsx
+++ b/src/components/customers/course-ticket-section.tsx
@@ -22,10 +22,14 @@ export function CourseTicketSection({
   initialTickets: CourseTicket[];
 }) {
   const [tickets, setTickets] = useState<CourseTicket[]>(initialTickets);
+  const [processingId, setProcessingId] = useState<string | null>(null);
 
   const handleUseSession = async (ticketId: string) => {
     const ticket = tickets.find((t) => t.id === ticketId);
     if (!ticket || ticket.used_sessions >= ticket.total_sessions) return;
+    if (processingId) return; // Prevent double-click
+
+    setProcessingId(ticketId);
 
     const supabase = createClient();
     const newUsed = ticket.used_sessions + 1;
@@ -46,6 +50,8 @@ export function CourseTicketSection({
         )
       );
     }
+
+    setProcessingId(null);
   };
 
   return (
@@ -94,9 +100,10 @@ export function CourseTicketSection({
                   {isActive && remaining > 0 && (
                     <button
                       onClick={() => handleUseSession(ticket.id)}
-                      className="text-xs bg-accent/10 text-accent px-3 py-1.5 rounded-lg hover:bg-accent/20 transition-colors min-h-[32px]"
+                      disabled={processingId !== null}
+                      className="text-xs bg-accent/10 text-accent px-3 py-1.5 rounded-lg hover:bg-accent/20 transition-colors min-h-[32px] disabled:opacity-50"
                     >
-                      1回使用する
+                      {processingId === ticket.id ? "処理中..." : "1回使用する"}
                     </button>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- 予約メニュー中間テーブル（appointment_menus）のINSERT/DELETE操作にエラーハンドリングを追加
- ガイドページ「全部入り」料金の計算ミスを修正（5,480円→7,080円）
- ガイドページのボタンラベルを実UIの「+ カルテ作成」に合わせて修正
- 回数券「1回使用する」ボタンに二重クリック防止（loading state）を追加

## Test plan
- [x] `next build` 全ページ正常コンパイル確認済み
- [ ] 予約登録/編集時にメニュー選択してエラーなく保存できること
- [ ] ガイドページの料金表示が正しいこと
- [ ] 回数券の「1回使用する」ボタン連打でも1回しか消化されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)