### PR TITLE
feat: テスターFB第2弾 - UI改善・売上管理・パフォーマンス最適化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,17 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // 認証済みルート: ブラウザキャッシュを無効化
+        // デプロイ後に古いHTMLが表示される問題を防止
+        source: "/(dashboard|customers|appointments|records|settings)/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, must-revalidate",
+          },
+        ],
+      },
+      {
         // 全ページに適用
         source: "/(.*)",
         headers: [

--- a/src/app/(dashboard)/appointments/loading.tsx
+++ b/src/app/(dashboard)/appointments/loading.tsx
@@ -1,0 +1,18 @@
+export default function AppointmentsLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="h-7 w-24 bg-border rounded-lg animate-pulse" />
+        <div className="h-10 w-24 bg-border rounded-xl animate-pulse" />
+      </div>
+      <div className="flex gap-2">
+        <div className="h-10 w-16 bg-border rounded-xl animate-pulse" />
+        <div className="h-10 w-16 bg-border rounded-xl animate-pulse" />
+      </div>
+      <div className="bg-surface border border-border rounded-xl px-4 py-3 h-12 animate-pulse" />
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="bg-surface border border-border rounded-xl p-3 h-24 animate-pulse" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/appointments/new/page.tsx
+++ b/src/app/(dashboard)/appointments/new/page.tsx
@@ -49,6 +49,7 @@ function NewAppointmentForm() {
   const [startMinute, setStartMinute] = useState("00");
   const [endHour, setEndHour] = useState("11");
   const [endMinute, setEndMinute] = useState("00");
+  const [isEndTimeManual, setIsEndTimeManual] = useState(false);
   const [source, setSource] = useState("direct");
   const [memo, setMemo] = useState("");
 
@@ -94,7 +95,8 @@ function NewAppointmentForm() {
   };
 
   // Auto-calculate end time from selected menus' total duration
-  const updateEndTimeFromMenus = (menuIds: string[], sH: string, sM: string) => {
+  const updateEndTimeFromMenus = (menuIds: string[], sH: string, sM: string, forceCalc = false) => {
+    if (!forceCalc && isEndTimeManual) return;
     const totalDuration = menuIds.reduce((sum, id) => {
       const menu = menus.find((m) => m.id === id);
       return sum + (menu?.duration_minutes ?? 0);
@@ -113,7 +115,8 @@ function NewAppointmentForm() {
       ? selectedMenuIds.filter((id) => id !== menuId)
       : [...selectedMenuIds, menuId];
     setSelectedMenuIds(newIds);
-    updateEndTimeFromMenus(newIds, startHour, startMinute);
+    setIsEndTimeManual(false);
+    updateEndTimeFromMenus(newIds, startHour, startMinute, true);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -377,11 +380,21 @@ function NewAppointmentForm() {
 
         {/* End time */}
         <div>
-          <label className="block text-sm font-medium mb-1.5">終了予定時間</label>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="block text-sm font-medium">終了予定時間</label>
+            {selectedMenuIds.length > 0 && (
+              <span className={`text-xs ${isEndTimeManual ? "text-orange-500" : "text-accent"}`}>
+                {isEndTimeManual ? "手動設定" : "メニューから自動計算"}
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <select
               value={endHour}
-              onChange={(e) => setEndHour(e.target.value)}
+              onChange={(e) => {
+                setEndHour(e.target.value);
+                setIsEndTimeManual(true);
+              }}
               className="flex-1 rounded-xl border border-border bg-surface px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
             >
               {Array.from({ length: 24 }, (_, i) => (
@@ -391,7 +404,10 @@ function NewAppointmentForm() {
             <span className="text-lg font-medium">:</span>
             <select
               value={endMinute}
-              onChange={(e) => setEndMinute(e.target.value)}
+              onChange={(e) => {
+                setEndMinute(e.target.value);
+                setIsEndTimeManual(true);
+              }}
               className="flex-1 rounded-xl border border-border bg-surface px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
             >
               {["00", "15", "30", "45"].map((m) => (
@@ -399,6 +415,18 @@ function NewAppointmentForm() {
               ))}
             </select>
           </div>
+          {isEndTimeManual && selectedMenuIds.length > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                setIsEndTimeManual(false);
+                updateEndTimeFromMenus(selectedMenuIds, startHour, startMinute, true);
+              }}
+              className="text-xs text-accent hover:underline mt-1"
+            >
+              自動計算に戻す
+            </button>
+          )}
         </div>
 
         {/* Menu multi-select */}

--- a/src/app/(dashboard)/customers/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/edit/page.tsx
@@ -7,15 +7,6 @@ import type { Database } from "@/types/database";
 
 type Customer = Database["public"]["Tables"]["customers"]["Row"];
 
-const SKIN_TYPES = [
-  { value: "", label: "選択してください" },
-  { value: "普通肌", label: "普通肌" },
-  { value: "乾燥肌", label: "乾燥肌" },
-  { value: "脂性肌", label: "脂性肌" },
-  { value: "混合肌", label: "混合肌" },
-  { value: "敏感肌", label: "敏感肌" },
-];
-
 const MARITAL_STATUSES = [
   { value: "", label: "選択してください" },
   { value: "未婚", label: "未婚" },
@@ -40,7 +31,6 @@ export default function EditCustomerPage() {
     marital_status: "",
     has_children: "",
     dm_allowed: "true",
-    skin_type: "",
     height_cm: "",
     weight_kg: "",
     allergies: "",
@@ -69,7 +59,6 @@ export default function EditCustomerPage() {
           marital_status: data.marital_status ?? "",
           has_children: data.has_children === null ? "" : data.has_children ? "true" : "false",
           dm_allowed: data.dm_allowed === false ? "false" : "true",
-          skin_type: data.skin_type ?? "",
           height_cm: data.height_cm !== null ? String(data.height_cm) : "",
           weight_kg: data.weight_kg !== null ? String(data.weight_kg) : "",
           allergies: data.allergies ?? "",
@@ -105,7 +94,6 @@ export default function EditCustomerPage() {
         marital_status: form.marital_status || null,
         has_children: form.has_children === "" ? null : form.has_children === "true",
         dm_allowed: form.dm_allowed === "true",
-        skin_type: form.skin_type || null,
         height_cm: form.height_cm ? parseFloat(form.height_cm) : null,
         weight_kg: form.weight_kg ? parseFloat(form.weight_kg) : null,
         allergies: form.allergies || null,
@@ -319,21 +307,6 @@ export default function EditCustomerPage() {
         {/* 施術関連情報 */}
         <div className="bg-surface border border-border rounded-2xl p-5 space-y-4">
           <h3 className="font-bold text-sm text-text-light">施術関連情報</h3>
-
-          <div>
-            <label className="block text-sm font-medium mb-1.5">肌質</label>
-            <select
-              value={form.skin_type}
-              onChange={(e) => updateField("skin_type", e.target.value)}
-              className={inputClass}
-            >
-              {SKIN_TYPES.map((type) => (
-                <option key={type.value} value={type.value}>
-                  {type.label}
-                </option>
-              ))}
-            </select>
-          </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div>

--- a/src/app/(dashboard)/customers/[id]/loading.tsx
+++ b/src/app/(dashboard)/customers/[id]/loading.tsx
@@ -1,0 +1,16 @@
+export default function CustomerDetailLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="h-7 w-32 bg-border rounded-lg animate-pulse" />
+          <div className="h-4 w-24 bg-border rounded-lg animate-pulse mt-1" />
+        </div>
+        <div className="h-4 w-8 bg-border rounded animate-pulse" />
+      </div>
+      <div className="bg-surface border border-border rounded-2xl p-5 h-36 animate-pulse" />
+      <div className="bg-surface border border-border rounded-2xl p-5 h-28 animate-pulse" />
+      <div className="bg-surface border border-border rounded-2xl p-5 h-48 animate-pulse" />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/customers/loading.tsx
+++ b/src/app/(dashboard)/customers/loading.tsx
@@ -1,0 +1,19 @@
+export default function CustomersLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="h-7 w-24 bg-border rounded-lg animate-pulse" />
+        <div className="h-10 w-16 bg-border rounded-xl animate-pulse" />
+      </div>
+      <div className="h-12 bg-surface border border-border rounded-xl animate-pulse" />
+      <div className="flex gap-2">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-8 w-20 bg-border rounded-lg animate-pulse" />
+        ))}
+      </div>
+      {[...Array(5)].map((_, i) => (
+        <div key={i} className="bg-surface border border-border rounded-xl p-4 h-16 animate-pulse" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -4,15 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
-const SKIN_TYPES = [
-  { value: "", label: "選択してください" },
-  { value: "普通肌", label: "普通肌" },
-  { value: "乾燥肌", label: "乾燥肌" },
-  { value: "脂性肌", label: "脂性肌" },
-  { value: "混合肌", label: "混合肌" },
-  { value: "敏感肌", label: "敏感肌" },
-];
-
 const MARITAL_STATUSES = [
   { value: "", label: "選択してください" },
   { value: "未婚", label: "未婚" },
@@ -36,7 +27,6 @@ export default function NewCustomerPage() {
     marital_status: "",
     has_children: "",
     dm_allowed: "true",
-    skin_type: "",
     height_cm: "",
     weight_kg: "",
     allergies: "",
@@ -87,7 +77,6 @@ export default function NewCustomerPage() {
       marital_status: form.marital_status || null,
       has_children: form.has_children === "" ? null : form.has_children === "true",
       dm_allowed: form.dm_allowed === "true",
-      skin_type: form.skin_type || null,
       height_cm: form.height_cm ? parseFloat(form.height_cm) : null,
       weight_kg: form.weight_kg ? parseFloat(form.weight_kg) : null,
       allergies: form.allergies || null,
@@ -280,22 +269,6 @@ export default function NewCustomerPage() {
         {/* 施術関連情報 */}
         <div className="bg-surface border border-border rounded-2xl p-5 space-y-4">
           <h3 className="font-bold text-sm text-text-light">施術関連情報</h3>
-
-          {/* 肌質 */}
-          <div>
-            <label className="block text-sm font-medium mb-1.5">肌質</label>
-            <select
-              value={form.skin_type}
-              onChange={(e) => updateField("skin_type", e.target.value)}
-              className={inputClass}
-            >
-              {SKIN_TYPES.map((type) => (
-                <option key={type.value} value={type.value}>
-                  {type.label}
-                </option>
-              ))}
-            </select>
-          </div>
 
           {/* 身体情報 */}
           <div className="grid grid-cols-2 gap-3">

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,22 @@
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="h-7 w-40 bg-border rounded-lg animate-pulse" />
+        <div className="h-4 w-24 bg-border rounded-lg animate-pulse mt-1" />
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="bg-surface border border-border rounded-2xl p-3 h-20 animate-pulse" />
+        ))}
+      </div>
+      <div className="bg-surface border border-border rounded-2xl p-5 h-36 animate-pulse" />
+      <div>
+        <div className="h-5 w-28 bg-border rounded-lg animate-pulse mb-3" />
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="bg-surface border border-border rounded-xl p-3 h-16 animate-pulse mb-2" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -513,7 +513,21 @@ export type Database = {
       };
     };
     Views: Record<string, never>;
-    Functions: Record<string, never>;
+    Functions: {
+      get_lapsed_customers: {
+        Args: {
+          p_salon_id: string;
+          p_days_threshold?: number;
+        };
+        Returns: {
+          id: string;
+          last_name: string;
+          first_name: string;
+          last_visit_date: string;
+          days_since: number;
+        }[];
+      };
+    };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;
   };

--- a/supabase/migrations/00009_lapsed_customers_function.sql
+++ b/supabase/migrations/00009_lapsed_customers_function.sql
@@ -1,0 +1,27 @@
+-- 離脱顧客を効率的に取得するDB関数
+-- ダッシュボードで全顧客+全施術記録をフェッチする代わりにSQL集計を使用
+CREATE OR REPLACE FUNCTION get_lapsed_customers(p_salon_id uuid, p_days_threshold integer DEFAULT 60)
+RETURNS TABLE (
+  id uuid,
+  last_name text,
+  first_name text,
+  last_visit_date date,
+  days_since integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+  SELECT
+    c.id,
+    c.last_name,
+    c.first_name,
+    MAX(tr.treatment_date)::date AS last_visit_date,
+    (CURRENT_DATE - MAX(tr.treatment_date)::date) AS days_since
+  FROM customers c
+  INNER JOIN treatment_records tr ON tr.customer_id = c.id
+  WHERE c.salon_id = p_salon_id
+  GROUP BY c.id, c.last_name, c.first_name
+  HAVING (CURRENT_DATE - MAX(tr.treatment_date)::date) >= p_days_threshold
+  ORDER BY days_since DESC;
+$$;


### PR DESCRIPTION
## Summary

テスターのサロンオーナーから受けた追加フィードバック5件を一括対応。

- **Phase 1**: 肌質（skin_type）フィールドをUIから削除（汎用サロン向けに不要。DB列は後方互換のため維持）
- **Phase 2**: 予約終了時間のUX改善 — 自動計算/手動入力モードを明示表示＋「自動計算に戻す」リセットボタン追加
- **Phase 3**: 顧客詳細に売上サマリー（施術+物販+回数券の合計）追加、ダッシュボードに今月の売上集計追加
- **Phase 4**: 離脱顧客クエリをDB関数化（`get_lapsed_customers` RPC）でデータ転送量を削減、4画面にスケルトンスクリーン追加
- **Phase 5**: 認証済みルートに `Cache-Control: no-store, must-revalidate` ヘッダーを追加（デプロイ後の反映安定化）

## Changed files (13 files)

| Action | File | Phase |
|--------|------|-------|
| UPDATE | `src/app/(dashboard)/customers/new/page.tsx` | 1 |
| UPDATE | `src/app/(dashboard)/customers/[id]/edit/page.tsx` | 1 |
| UPDATE | `src/app/(dashboard)/customers/[id]/page.tsx` | 1, 3 |
| UPDATE | `src/app/(dashboard)/appointments/new/page.tsx` | 2 |
| UPDATE | `src/app/(dashboard)/appointments/[id]/edit/page.tsx` | 2 |
| UPDATE | `src/app/(dashboard)/dashboard/page.tsx` | 3, 4 |
| UPDATE | `src/types/database.ts` | 4 |
| UPDATE | `next.config.ts` | 5 |
| NEW | `supabase/migrations/00009_lapsed_customers_function.sql` | 4 |
| NEW | `src/app/(dashboard)/dashboard/loading.tsx` | 4 |
| NEW | `src/app/(dashboard)/customers/loading.tsx` | 4 |
| NEW | `src/app/(dashboard)/appointments/loading.tsx` | 4 |
| NEW | `src/app/(dashboard)/customers/[id]/loading.tsx` | 4 |

## Test plan

- [ ] 顧客新規作成・編集で肌質フィールドが表示されないこと確認
- [ ] 予約作成でメニュー選択時に終了時間が自動計算され、手動変更時に「手動設定」表示に切り替わること確認
- [ ] 顧客詳細で施術・物販・回数券の合計金額が表示されること確認
- [ ] ダッシュボードで今月の売上集計が表示されること確認
- [ ] ダッシュボード遷移時にスケルトンスクリーンが表示されること確認
- [ ] デプロイ後、DevToolsで認証ルートのCache-Controlヘッダーを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)