### PR TITLE
feat: 機能拡充 — 卒業・誕生日・カレンダー・売上レポート

### DIFF
--- a/src/app/(dashboard)/sales/page.tsx
+++ b/src/app/(dashboard)/sales/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+
+type MonthlySales = {
+  month: number;
+  treatment_sales: number;
+  product_sales: number;
+  ticket_sales: number;
+};
+
+const MONTH_NAMES = [
+  "1月", "2月", "3月", "4月", "5月", "6月",
+  "7月", "8月", "9月", "10月", "11月", "12月",
+];
+
+function formatYen(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
+
+function getChangePercent(current: number, previous: number): { text: string; color: string } | null {
+  if (previous === 0 && current === 0) return null;
+  if (previous === 0) return { text: "New", color: "text-green-600" };
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct > 0) return { text: `+${pct}%`, color: "text-green-600" };
+  if (pct < 0) return { text: `${pct}%`, color: "text-red-500" };
+  return { text: "±0%", color: "text-text-light" };
+}
+
+export default function SalesPage() {
+  const [data, setData] = useState<MonthlySales[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [year, setYear] = useState(new Date().getFullYear());
+
+  const loadSales = useCallback(async (targetYear: number) => {
+    setLoading(true);
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+
+    const { data: salesData } = await supabase.rpc("get_monthly_sales_summary", {
+      p_salon_id: salon.id,
+      p_year: targetYear,
+    });
+
+    setData((salesData as MonthlySales[]) ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadSales(year);
+  }, [year, loadSales]);
+
+  const currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth(); // 0-indexed
+
+  // Calculate totals
+  const yearTotal = data.reduce(
+    (acc, m) => ({
+      treatment: acc.treatment + m.treatment_sales,
+      product: acc.product + m.product_sales,
+      ticket: acc.ticket + m.ticket_sales,
+    }),
+    { treatment: 0, product: 0, ticket: 0 }
+  );
+  const grandTotal = yearTotal.treatment + yearTotal.product + yearTotal.ticket;
+
+  // Find max monthly total for bar scaling
+  const monthlyTotals = data.map(
+    (m) => m.treatment_sales + m.product_sales + m.ticket_sales
+  );
+  const maxMonthly = Math.max(...monthlyTotals, 1);
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="売上レポート" backLabel="戻る" />
+
+      {/* Year navigation */}
+      <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
+        <button
+          onClick={() => setYear((y) => y - 1)}
+          className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+          </svg>
+        </button>
+        <span className="font-bold text-lg">{year}年</span>
+        <button
+          onClick={() => setYear((y) => y + 1)}
+          disabled={year >= currentYear}
+          className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center disabled:opacity-30"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="text-center text-text-light py-8">読み込み中...</div>
+      ) : (
+        <>
+          {/* Annual summary card */}
+          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm text-text-light">年間合計</span>
+              <span className="text-2xl font-bold">{formatYen(grandTotal)}</span>
+            </div>
+            <div className="flex gap-4">
+              <div className="flex items-center gap-1.5">
+                <div className="w-2.5 h-2.5 rounded-sm bg-accent" />
+                <span className="text-xs text-text-light">施術</span>
+                <span className="text-xs font-medium">{formatYen(yearTotal.treatment)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-2.5 h-2.5 rounded-sm bg-blue-400" />
+                <span className="text-xs text-text-light">物販</span>
+                <span className="text-xs font-medium">{formatYen(yearTotal.product)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-2.5 h-2.5 rounded-sm bg-amber-400" />
+                <span className="text-xs text-text-light">回数券</span>
+                <span className="text-xs font-medium">{formatYen(yearTotal.ticket)}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Monthly breakdown */}
+          <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+            <h3 className="font-bold text-sm">月別推移</h3>
+            <div className="space-y-2">
+              {data.map((m, idx) => {
+                const total = m.treatment_sales + m.product_sales + m.ticket_sales;
+                const prevTotal = idx > 0
+                  ? data[idx - 1].treatment_sales + data[idx - 1].product_sales + data[idx - 1].ticket_sales
+                  : 0;
+                const change = idx > 0 ? getChangePercent(total, prevTotal) : null;
+
+                // Skip future months in current year
+                if (year === currentYear && m.month - 1 > currentMonth) return null;
+
+                const treatmentPct = maxMonthly > 0 ? (m.treatment_sales / maxMonthly) * 100 : 0;
+                const productPct = maxMonthly > 0 ? (m.product_sales / maxMonthly) * 100 : 0;
+                const ticketPct = maxMonthly > 0 ? (m.ticket_sales / maxMonthly) * 100 : 0;
+
+                return (
+                  <div key={m.month} className="space-y-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-medium w-8 shrink-0">{MONTH_NAMES[m.month - 1]}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-bold">{formatYen(total)}</span>
+                        {change && (
+                          <span className={`text-[10px] font-medium ${change.color}`}>
+                            {change.text}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {/* Stacked bar */}
+                    <div className="h-4 bg-background rounded-full overflow-hidden flex">
+                      {treatmentPct > 0 && (
+                        <div
+                          className="bg-accent h-full transition-all duration-500"
+                          style={{ width: `${treatmentPct}%` }}
+                        />
+                      )}
+                      {productPct > 0 && (
+                        <div
+                          className="bg-blue-400 h-full transition-all duration-500"
+                          style={{ width: `${productPct}%` }}
+                        />
+                      )}
+                      {ticketPct > 0 && (
+                        <div
+                          className="bg-amber-400 h-full transition-all duration-500"
+                          style={{ width: `${ticketPct}%` }}
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/lapsed-customers-section.tsx
+++ b/src/components/dashboard/lapsed-customers-section.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+type LapsedCustomer = {
+  id: string;
+  last_name: string;
+  first_name: string;
+  last_visit_date: string;
+  days_since: number;
+};
+
+export function LapsedCustomersSection({
+  initialCustomers,
+}: {
+  initialCustomers: LapsedCustomer[];
+}) {
+  const [customers, setCustomers] = useState(initialCustomers);
+  const [graduatingId, setGraduatingId] = useState<string | null>(null);
+
+  const handleGraduate = async (customer: LapsedCustomer) => {
+    setGraduatingId(customer.id);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("customers")
+      .update({ graduated_at: new Date().toISOString() })
+      .eq("id", customer.id);
+
+    if (!error) {
+      setCustomers((prev) => prev.filter((c) => c.id !== customer.id));
+    }
+    setGraduatingId(null);
+  };
+
+  if (customers.length === 0) return null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-bold">
+          ご無沙汰のお客様
+          <span className="text-xs font-normal text-text-light ml-2">
+            60日以上
+          </span>
+        </h3>
+        {initialCustomers.length > 3 && (
+          <Link
+            href="/customers"
+            className="text-xs text-accent hover:underline"
+          >
+            他{initialCustomers.length - 3}名 →
+          </Link>
+        )}
+      </div>
+      <div className="space-y-2">
+        {customers.slice(0, 3).map((c) => (
+          <div
+            key={c.id}
+            className="bg-surface border border-orange-200 rounded-xl p-3 flex items-center justify-between"
+          >
+            <Link
+              href={`/customers/${c.id}`}
+              className="flex-1 min-w-0 hover:opacity-70 transition-opacity"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-sm truncate">
+                  {c.last_name} {c.first_name}
+                </span>
+                <span
+                  className={`text-xs font-medium shrink-0 ml-2 ${
+                    c.days_since >= 90 ? "text-red-500" : "text-orange-500"
+                  }`}
+                >
+                  {c.days_since}日前
+                </span>
+              </div>
+            </Link>
+            <button
+              onClick={() => handleGraduate(c)}
+              disabled={graduatingId === c.id}
+              className="ml-3 text-[10px] text-text-light border border-border rounded-lg px-2 py-1 hover:bg-background transition-colors disabled:opacity-50 shrink-0"
+              title="ご無沙汰リストから非表示にする"
+            >
+              {graduatingId === c.id ? "..." : "卒業"}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/dashboard-header.tsx
+++ b/src/components/layout/dashboard-header.tsx
@@ -207,12 +207,22 @@ export function DashboardHeader() {
           {/* Customers & More */}
           {navItems.slice(2).map((item) => {
             if (item.icon === "more") {
-              const isActive = moreOpen || pathname.startsWith("/settings") || pathname === "/guide";
+              const isActive = moreOpen || pathname.startsWith("/settings") || pathname === "/guide" || pathname.startsWith("/sales");
               return (
                 <div key="more" ref={moreRef} className="relative flex flex-col items-center">
                   {/* More menu popup */}
                   {moreOpen && (
                     <div className="absolute bottom-14 right-0 bg-surface rounded-2xl shadow-lg border border-border py-2 w-48 z-50">
+                      <Link
+                        href="/sales"
+                        className="flex items-center gap-3 px-4 py-3 hover:bg-background transition-colors"
+                        onClick={() => setMoreOpen(false)}
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-text-light">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+                        </svg>
+                        <span className="text-sm font-medium">売上レポート</span>
+                      </Link>
                       <Link
                         href="/settings"
                         className="flex items-center gap-3 px-4 py-3 hover:bg-background transition-colors"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -71,6 +71,7 @@ export type Database = {
           height_cm: number | null;
           weight_kg: number | null;
           treatment_goal: string | null;
+          graduated_at: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -94,6 +95,7 @@ export type Database = {
           height_cm?: number | null;
           weight_kg?: number | null;
           treatment_goal?: string | null;
+          graduated_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -117,6 +119,7 @@ export type Database = {
           height_cm?: number | null;
           weight_kg?: number | null;
           treatment_goal?: string | null;
+          graduated_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -544,6 +547,18 @@ export type Database = {
           first_name: string;
           last_visit_date: string;
           days_since: number;
+        }[];
+      };
+      get_monthly_sales_summary: {
+        Args: {
+          p_salon_id: string;
+          p_year: number;
+        };
+        Returns: {
+          month: number;
+          treatment_sales: number;
+          product_sales: number;
+          ticket_sales: number;
         }[];
       };
     };


### PR DESCRIPTION
## Summary
- **卒業機能**: ご無沙汰お客様を「卒業」ボタンで非表示化（データは保持、`graduated_at`列追加）
- **誕生日アラート**: ダッシュボードに今月誕生日のお客様一覧を表示（プレゼント準備用）
- **月別カレンダー**: 予約管理に月別カレンダービュー追加（CSS Grid、予約ドット表示、タップで日別へ）
- **売上レポート**: 年間売上推移ページ（施術・物販・回数券の3色棒グラフ、前月比表示）

### 技術的変更
- DBマイグレーション: `00011_customer_graduation`, `00012_monthly_sales_summary`
- 新ファイル: `sales/page.tsx`, `lapsed-customers-section.tsx`
- 更新: `appointments/page.tsx`, `dashboard/page.tsx`, `dashboard-header.tsx`, `database.ts`
- CSS-onlyグラフ（外部ライブラリ不使用）

## Test plan
- [ ] ダッシュボードでご無沙汰お客様の「卒業」ボタンが動作すること
- [ ] 卒業後もカルテ・顧客情報が保持されていること
- [ ] 誕生日カードが当月に表示されること
- [ ] 予約管理の「月別」タブでカレンダーが表示されること
- [ ] カレンダーの日付タップで日別表示に切り替わること
- [ ] 売上レポートで年間推移・前月比が表示されること
- [ ] 「もっと」メニューから売上レポートにアクセスできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)