### PR TITLE
fix: セキュリティ・パフォーマンス・整合性の包括的修正

### DIFF
--- a/src/app/(dashboard)/appointments/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/appointments/[id]/edit/page.tsx
@@ -270,6 +270,9 @@ export default function EditAppointmentPage() {
 
     if (deleteError) {
       console.error("Junction delete error:", deleteError);
+      setError(`メニュー情報の更新に失敗しました: ${deleteError.message}`);
+      setSaving(false);
+      return;
     }
 
     if (selectedMenuIds.length > 0) {
@@ -285,6 +288,9 @@ export default function EditAppointmentPage() {
       const { error: junctionError } = await supabase.from("appointment_menus").insert(junctionRows);
       if (junctionError) {
         console.error("Junction insert error:", junctionError);
+        setError(`メニュー情報の保存に失敗しました: ${junctionError.message}`);
+        setSaving(false);
+        return;
       }
     }
 

--- a/src/app/(dashboard)/customers/[id]/purchases/new/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/purchases/new/page.tsx
@@ -65,6 +65,10 @@ export default function NewPurchasePage() {
       setError("商品名を入力してください");
       return;
     }
+    if (!salonId) {
+      setError("サロン情報の読み込み中です。しばらくお待ちください。");
+      return;
+    }
     setError("");
     setLoading(true);
 

--- a/src/app/(dashboard)/customers/[id]/tickets/new/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/tickets/new/page.tsx
@@ -69,6 +69,10 @@ export default function NewTicketPage() {
       setError("回数は1以上を入力してください");
       return;
     }
+    if (!salonId) {
+      setError("サロン情報の読み込み中です。しばらくお待ちください。");
+      return;
+    }
     setError("");
     setLoading(true);
 

--- a/src/app/(dashboard)/records/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/records/[id]/edit/page.tsx
@@ -185,8 +185,8 @@ export default function EditRecordPage() {
           >
             <option value="">選択してください</option>
             {menus.map((menu) => (
-              <option key={menu.id} value={menu.id}>
-                {menu.name}
+              <option key={menu.id} value={menu.id} disabled={!menu.is_active && menu.id !== form.menu_id}>
+                {menu.name}{!menu.is_active ? "（非アクティブ）" : ""}
               </option>
             ))}
           </select>

--- a/src/app/(dashboard)/settings/business-hours/page.tsx
+++ b/src/app/(dashboard)/settings/business-hours/page.tsx
@@ -74,7 +74,11 @@ export default function BusinessHoursPage() {
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user) return;
+    if (!user) {
+      setError("認証エラーです。再ログインしてください。");
+      setSaving(false);
+      return;
+    }
 
     const { error: updateError } = await supabase
       .from("salons")

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,10 +1,24 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
+// オープンリダイレクト防止: 許可するパスのみリダイレクト
+const ALLOWED_REDIRECT_PATHS = ["/dashboard", "/setup", "/settings", "/update-password"];
+
+function getSafeRedirectPath(next: string | null): string | null {
+  if (!next) return null;
+  // 相対パスのみ許可（//external.com や https:// を拒否）
+  if (!next.startsWith("/") || next.startsWith("//")) return null;
+  // 許可リストに含まれるパスかチェック
+  if (ALLOWED_REDIRECT_PATHS.some((path) => next.startsWith(path))) {
+    return next;
+  }
+  return null;
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/setup";
+  const next = getSafeRedirectPath(searchParams.get("next"));
 
   if (code) {
     const supabase = await createClient();
@@ -12,7 +26,7 @@ export async function GET(request: Request) {
 
     if (!error) {
       // If redirecting to a specific page (e.g., password reset), respect it
-      if (next !== "/setup") {
+      if (next) {
         return NextResponse.redirect(`${origin}${next}`);
       }
 

--- a/src/lib/business-hours.ts
+++ b/src/lib/business-hours.ts
@@ -57,7 +57,9 @@ export const DEFAULT_BUSINESS_HOURS: BusinessHours = {
 
 /** "HH:MM" → 分 */
 export function timeToMinutes(time: string): number {
-  const [h, m] = time.split(":").map(Number);
+  const parts = time.split(":");
+  const h = Number(parts[0]) || 0;
+  const m = Number(parts[1]) || 0;
   return h * 60 + m;
 }
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -34,7 +34,7 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   // Protected routes: redirect to login if not authenticated
-  const protectedPaths = ["/dashboard", "/customers", "/records", "/settings", "/setup", "/appointments", "/guide"];
+  const protectedPaths = ["/dashboard", "/customers", "/records", "/settings", "/setup", "/appointments", "/guide", "/sales"];
   const isProtectedRoute = protectedPaths.some((path) =>
     request.nextUrl.pathname.startsWith(path)
   );

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -561,6 +561,15 @@ export type Database = {
           ticket_sales: number;
         }[];
       };
+      use_course_ticket_session: {
+        Args: {
+          p_ticket_id: string;
+        };
+        Returns: {
+          used_sessions: number;
+          status: string;
+        };
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/supabase/migrations/00011_security_and_integrity_fixes.sql
+++ b/supabase/migrations/00011_security_and_integrity_fixes.sql
@@ -1,0 +1,117 @@
+-- ========================================
+-- セキュリティ・整合性修正マイグレーション
+-- ========================================
+
+-- 1. [Critical] get_lapsed_customers: SECURITY DEFINER → SECURITY INVOKER
+--    SECURITY DEFINERはRLSをバイパスするため、任意のsalon_idで他サロンのデータを取得可能だった
+DROP FUNCTION IF EXISTS get_lapsed_customers(uuid, integer);
+
+CREATE OR REPLACE FUNCTION get_lapsed_customers(p_salon_id uuid, p_days_threshold integer DEFAULT 60)
+RETURNS TABLE (
+  id uuid,
+  last_name text,
+  first_name text,
+  last_visit_date date,
+  days_since integer
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    c.id,
+    c.last_name,
+    c.first_name,
+    MAX(tr.treatment_date)::date AS last_visit_date,
+    (CURRENT_DATE - MAX(tr.treatment_date)::date) AS days_since
+  FROM customers c
+  INNER JOIN treatment_records tr ON tr.customer_id = c.id
+  WHERE c.salon_id = p_salon_id
+  GROUP BY c.id, c.last_name, c.first_name
+  HAVING (CURRENT_DATE - MAX(tr.treatment_date)::date) >= p_days_threshold
+  ORDER BY days_since DESC;
+$$;
+
+-- 2. [Critical] NOT NULL制約追加（owner_id, salon_id, customer_id）
+--    NULLが入るとRLSポリシーが機能しなくなるため必須
+ALTER TABLE salons ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE customers ALTER COLUMN salon_id SET NOT NULL;
+ALTER TABLE treatment_records ALTER COLUMN customer_id SET NOT NULL;
+ALTER TABLE treatment_records ALTER COLUMN salon_id SET NOT NULL;
+
+-- 3. [Critical] コースチケットのアトミック消化用RPC関数
+--    クライアント側のread-then-writeの競合状態を防止
+CREATE OR REPLACE FUNCTION use_course_ticket_session(p_ticket_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_ticket record;
+  v_new_used integer;
+  v_new_status text;
+BEGIN
+  -- 行ロックで排他制御
+  SELECT * INTO v_ticket
+  FROM course_tickets
+  WHERE id = p_ticket_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'チケットが見つかりません';
+  END IF;
+
+  IF v_ticket.status != 'active' THEN
+    RAISE EXCEPTION 'このチケットは使用できません（ステータス: %）', v_ticket.status;
+  END IF;
+
+  IF v_ticket.used_sessions >= v_ticket.total_sessions THEN
+    RAISE EXCEPTION 'このチケットは全回数を消化済みです';
+  END IF;
+
+  v_new_used := v_ticket.used_sessions + 1;
+  v_new_status := CASE WHEN v_new_used >= v_ticket.total_sessions THEN 'completed' ELSE 'active' END;
+
+  UPDATE course_tickets
+  SET used_sessions = v_new_used,
+      status = v_new_status
+  WHERE id = p_ticket_id;
+
+  RETURN jsonb_build_object('used_sessions', v_new_used, 'status', v_new_status);
+END;
+$$;
+
+-- 4. [High] appointments.menu_id に ON DELETE SET NULL を追加
+--    メニュー削除時に予約が壊れないようにする
+ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_menu_id_fkey;
+ALTER TABLE appointments
+  ADD CONSTRAINT appointments_menu_id_fkey
+  FOREIGN KEY (menu_id) REFERENCES treatment_menus(id) ON DELETE SET NULL;
+
+-- 5. [High] appointments.treatment_record_id に ON DELETE SET NULL を追加
+ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_treatment_record_id_fkey;
+ALTER TABLE appointments
+  ADD CONSTRAINT appointments_treatment_record_id_fkey
+  FOREIGN KEY (treatment_record_id) REFERENCES treatment_records(id) ON DELETE SET NULL;
+
+-- 6. [High] course_tickets に CHECK制約追加
+ALTER TABLE course_tickets
+  ADD CONSTRAINT check_used_sessions_limit
+  CHECK (used_sessions >= 0 AND used_sessions <= total_sessions);
+
+-- 7. [Medium] Storage UPDATE ポリシー追加
+--    写真のメタデータ更新に必要
+CREATE POLICY "Salon owners can update their treatment photos"
+  ON storage.objects FOR UPDATE
+  USING (
+    bucket_id = 'treatment-photos'
+    AND auth.role() = 'authenticated'
+    AND (storage.foldername(name))[1] IN (
+      SELECT id::text FROM public.salons WHERE owner_id = auth.uid()
+    )
+  );
+
+-- 8. [Medium] salons テーブルにオーナーごとのユニーク制約
+--    1ユーザー1サロンを保証（現在のビジネスモデル）
+CREATE UNIQUE INDEX IF NOT EXISTS idx_salons_unique_owner
+  ON salons(owner_id);


### PR DESCRIPTION
## Summary
- 全ソースレビューで発見された **Critical 4件 / High 7件 / Medium 6件** の計17件を一括修正
- 新規マイグレーション `00011_security_and_integrity_fixes.sql` でDB側修正を適用
- TypeScript型チェック・Next.jsビルド共にエラーなし確認済み

## 修正内容

### 🔴 Critical
- `get_lapsed_customers` を SECURITY DEFINER → INVOKER に変更（他サロンデータ漏洩防止）
- Auth Callback のオープンリダイレクト脆弱性を修正（許可パスのホワイトリスト方式）
- コースチケット消化の競合状態をDB側RPC関数 `use_course_ticket_session` でアトミック化
- `salons.owner_id` / `customers.salon_id` / `treatment_records.customer_id,salon_id` に NOT NULL 制約追加

### 🟠 High
- `appointments.menu_id` / `treatment_record_id` に ON DELETE SET NULL 追加
- `course_tickets` に `used_sessions <= total_sessions` のCHECK制約追加
- 顧客一覧・顧客詳細の逐次クエリを `Promise.all()` で並列化（レスポンス改善）
- purchases/tickets新規作成で空salonIdの送信ガード追加
- `/sales` を middleware protectedPaths に追加
- 予約編集のjunction table更新にエラーハンドリング追加

### 🟡 Medium
- 施術記録編集で非アクティブメニューを disabled + ラベル表示
- 営業時間設定の認証失敗時 `setSaving(false)` 追加
- `timeToMinutes` のNaN防止（`|| 0` フォールバック）
- `deletePhoto` のエラーハンドリング改善（DB削除優先）
- Storage UPDATE ポリシー追加
- salons に owner_id ユニーク制約追加

## 変更ファイル（14件）
- `supabase/migrations/00011_security_and_integrity_fixes.sql` 🆕
- `src/app/auth/callback/route.ts`
- `src/components/customers/course-ticket-section.tsx`
- `src/app/(dashboard)/customers/page.tsx`
- `src/app/(dashboard)/customers/[id]/page.tsx`
- `src/app/(dashboard)/customers/[id]/purchases/new/page.tsx`
- `src/app/(dashboard)/customers/[id]/tickets/new/page.tsx`
- `src/app/(dashboard)/appointments/[id]/edit/page.tsx`
- `src/app/(dashboard)/records/[id]/edit/page.tsx`
- `src/app/(dashboard)/settings/business-hours/page.tsx`
- `src/lib/supabase/middleware.ts`
- `src/lib/supabase/storage.ts`
- `src/lib/business-hours.ts`
- `src/types/database.ts`

## Test plan
- [ ] ログイン→ダッシュボード表示確認
- [ ] 顧客一覧の表示速度改善を体感確認
- [ ] 顧客詳細ページの表示速度改善を体感確認
- [ ] コースチケット「1回使用する」が正常動作すること
- [ ] `/auth/callback?next=https://evil.com` でリダイレクトされないこと
- [ ] 購入記録/チケット登録で素早く保存ボタンを押してもエラーが出ること
- [ ] Supabase Dashboard でマイグレーション 00011 を適用確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)