### PR TITLE
feat: Phase5 — 在庫管理・確定申告サポート

### DIFF
--- a/src/app/(dashboard)/sales/inventory/consume/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/consume/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import type { Database } from "@/types/database";
+
+type Product = Database["public"]["Tables"]["products"]["Row"];
+
+const LOG_TYPES = [
+  { value: "sample_out", label: "サンプル消費" },
+  { value: "waste_out", label: "廃棄" },
+  { value: "return_in", label: "返品（入庫）" },
+];
+
+export default function ConsumePage() {
+  const router = useRouter();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [salonId, setSalonId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const today = (() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  })();
+
+  const [form, setForm] = useState({
+    product_id: "",
+    log_type: "sample_out",
+    quantity: "1",
+    reason: "",
+    logged_at: today,
+  });
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const loadProducts = async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+    setSalonId(salon.id);
+
+    const { data } = await supabase
+      .from("products")
+      .select("*")
+      .eq("salon_id", salon.id)
+      .eq("is_active", true)
+      .order("name")
+      .returns<Product[]>();
+
+    setProducts(data ?? []);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.product_id) {
+      setError("商品を選択してください");
+      return;
+    }
+    setError("");
+    setSuccess("");
+    setLoading(true);
+
+    const supabase = createClient();
+    const quantity = parseInt(form.quantity) || 1;
+    const isReturn = form.log_type === "return_in";
+
+    const { error: insertError } = await supabase.from("inventory_logs").insert({
+      salon_id: salonId,
+      product_id: form.product_id,
+      log_type: form.log_type,
+      quantity: isReturn ? quantity : -quantity, // 返品は正数、消費・廃棄は負数
+      reason: form.reason || null,
+      logged_at: form.logged_at,
+    });
+
+    if (insertError) {
+      setError("記録の登録に失敗しました");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    const product = products.find((p) => p.id === form.product_id);
+    const typeLabel = LOG_TYPES.find((t) => t.value === form.log_type)?.label ?? "";
+    setSuccess(`${product?.name ?? "商品"} ${quantity}個 の${typeLabel}を記録しました`);
+
+    // フォームリセット
+    setForm({
+      product_id: "",
+      log_type: form.log_type,
+      quantity: "1",
+      reason: "",
+      logged_at: form.logged_at,
+    });
+  };
+
+  const inputClass =
+    "w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors";
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="消費・廃棄記録"
+        backLabel="在庫管理"
+        backHref="/sales/inventory"
+        breadcrumbs={[
+          { label: "経営", href: "/sales" },
+          { label: "在庫管理", href: "/sales/inventory" },
+          { label: "消費・廃棄記録" },
+        ]}
+      />
+
+      {error && <ErrorAlert message={error} />}
+
+      {success && (
+        <div className="bg-green-50 text-green-700 text-sm rounded-xl px-4 py-3 flex items-center justify-between">
+          <span>{success}</span>
+          <button
+            type="button"
+            onClick={() => setSuccess("")}
+            className="text-xs underline"
+          >
+            閉じる
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-2xl p-5 space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1.5">
+            種別 <span className="text-error">*</span>
+          </label>
+          <div className="flex gap-1.5">
+            {LOG_TYPES.map((type) => (
+              <button
+                key={type.value}
+                type="button"
+                onClick={() => setForm({ ...form, log_type: type.value })}
+                className={`flex-1 text-sm font-medium py-2.5 rounded-xl transition-colors min-h-[44px] ${
+                  form.log_type === type.value
+                    ? "bg-accent text-white"
+                    : "bg-background border border-border text-text-light"
+                }`}
+              >
+                {type.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1.5">
+            商品 <span className="text-error">*</span>
+          </label>
+          <select
+            value={form.product_id}
+            onChange={(e) => setForm({ ...form, product_id: e.target.value })}
+            required
+            className={inputClass}
+          >
+            <option value="">商品を選択</option>
+            {products.map((product) => (
+              <option key={product.id} value={product.id}>
+                {product.name}
+                {product.category ? ` (${product.category})` : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              数量 <span className="text-error">*</span>
+            </label>
+            <input
+              type="number"
+              value={form.quantity}
+              onChange={(e) => setForm({ ...form, quantity: e.target.value })}
+              required
+              min="1"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1.5">日付</label>
+            <input
+              type="date"
+              value={form.logged_at}
+              onChange={(e) => setForm({ ...form, logged_at: e.target.value })}
+              required
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1.5">理由メモ</label>
+          <textarea
+            value={form.reason}
+            onChange={(e) => setForm({ ...form, reason: e.target.value })}
+            placeholder="理由や詳細を記録（任意）"
+            rows={2}
+            className={`${inputClass} resize-none`}
+          />
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="flex-1 bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
+          >
+            戻る
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex-1 bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors disabled:opacity-50 min-h-[48px]"
+          >
+            {loading ? "記録中..." : "記録する"}
+          </button>
+        </div>
+      </form>
+
+      {products.length === 0 && (
+        <div className="text-center text-text-light text-sm py-4">
+          商品が登録されていません。先に
+          <a href="/sales/inventory/products" className="text-accent hover:underline">商品マスタ</a>
+          から登録してください。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/loading.tsx
+++ b/src/app/(dashboard)/sales/inventory/loading.tsx
@@ -1,0 +1,36 @@
+export default function InventoryLoading() {
+  return (
+    <div className="space-y-4">
+      {/* Tabs skeleton */}
+      <div className="flex gap-1.5 bg-background rounded-xl p-1">
+        <div className="flex-1 h-[44px] bg-border rounded-lg animate-pulse" />
+        <div className="flex-1 h-[44px] bg-border rounded-lg animate-pulse" />
+      </div>
+
+      {/* Summary cards skeleton */}
+      <div className="grid grid-cols-3 gap-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="bg-surface border border-border rounded-xl p-4 animate-pulse">
+            <div className="h-3 bg-border rounded w-12 mb-2 mx-auto" />
+            <div className="h-6 bg-border rounded w-8 mx-auto" />
+          </div>
+        ))}
+      </div>
+
+      {/* Quick actions skeleton */}
+      <div className="grid grid-cols-2 gap-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="bg-surface border border-border rounded-xl p-4 h-14 animate-pulse" />
+        ))}
+      </div>
+
+      {/* Product list skeleton */}
+      <div className="bg-surface border border-border rounded-2xl p-4 animate-pulse space-y-3">
+        <div className="h-4 bg-border rounded w-20" />
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-12 bg-border rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { ManagementTabs } from "@/components/inventory/management-tabs";
+
+type InventoryItem = {
+  product_id: string;
+  product_name: string;
+  category: string | null;
+  base_sell_price: number;
+  base_cost_price: number;
+  reorder_point: number;
+  is_active: boolean;
+  current_stock: number;
+  stock_value: number;
+};
+
+export default function InventoryPage() {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasProducts, setHasProducts] = useState(false);
+
+  useEffect(() => {
+    loadInventory();
+  }, []);
+
+  const loadInventory = async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+
+    // 商品数を先にチェック（コスト最小）
+    const { count } = await supabase
+      .from("products")
+      .select("*", { count: "exact", head: true })
+      .eq("salon_id", salon.id);
+
+    if (!count || count === 0) {
+      setHasProducts(false);
+      setLoading(false);
+      return;
+    }
+
+    setHasProducts(true);
+
+    const { data } = await supabase.rpc("get_inventory_summary", {
+      p_salon_id: salon.id,
+    });
+
+    setItems((data as InventoryItem[]) ?? []);
+    setLoading(false);
+  };
+
+  const totalProducts = items.length;
+  const lowStockCount = items.filter((i) => i.current_stock <= i.reorder_point).length;
+  const totalStockValue = items.reduce((sum, i) => sum + (i.stock_value > 0 ? i.stock_value : 0), 0);
+
+  const quickActions = [
+    { href: "/sales/inventory/receive", label: "仕入記録", icon: "📦" },
+    { href: "/sales/inventory/consume", label: "消費・廃棄", icon: "📋" },
+    { href: "/sales/inventory/stocktake", label: "棚卸し", icon: "📊" },
+    { href: "/sales/inventory/tax-report", label: "確定申告", icon: "📄" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <ManagementTabs />
+
+      {loading ? (
+        /* Skeleton */
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="bg-surface border border-border rounded-xl p-4 animate-pulse">
+                <div className="h-3 bg-border rounded w-12 mb-2" />
+                <div className="h-6 bg-border rounded w-8" />
+              </div>
+            ))}
+          </div>
+          <div className="bg-surface border border-border rounded-xl p-4 animate-pulse">
+            <div className="h-4 bg-border rounded w-24 mb-4" />
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-12 bg-border rounded" />
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : !hasProducts ? (
+        /* Onboarding */
+        <div className="bg-surface border border-border rounded-2xl p-8 text-center space-y-4">
+          <div className="text-4xl">📦</div>
+          <h3 className="text-lg font-bold">在庫管理を始めましょう</h3>
+          <p className="text-sm text-text-light">
+            商品を登録すると、在庫数の管理や<br />
+            確定申告用のレポートが使えるようになります
+          </p>
+          <Link
+            href="/sales/inventory/products"
+            className="inline-block bg-accent hover:bg-accent-light text-white font-medium rounded-xl px-6 py-3 transition-colors min-h-[48px]"
+          >
+            商品を登録する
+          </Link>
+        </div>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="bg-surface border border-border rounded-xl p-4 text-center">
+              <p className="text-xs text-text-light">商品数</p>
+              <p className="text-xl font-bold mt-1">{totalProducts}</p>
+            </div>
+            <div className={`bg-surface border rounded-xl p-4 text-center ${lowStockCount > 0 ? "border-amber-300 bg-amber-50" : "border-border"}`}>
+              <p className="text-xs text-text-light">要発注</p>
+              <p className={`text-xl font-bold mt-1 ${lowStockCount > 0 ? "text-amber-600" : ""}`}>
+                {lowStockCount}
+              </p>
+            </div>
+            <div className="bg-surface border border-border rounded-xl p-4 text-center">
+              <p className="text-xs text-text-light">在庫評価額</p>
+              <p className="text-lg font-bold mt-1">¥{totalStockValue.toLocaleString()}</p>
+            </div>
+          </div>
+
+          {/* Quick actions */}
+          <div className="grid grid-cols-2 gap-3">
+            {quickActions.map((action) => (
+              <Link
+                key={action.href}
+                href={action.href}
+                className="bg-surface border border-border rounded-xl p-4 flex items-center gap-3 hover:bg-background transition-colors min-h-[56px]"
+              >
+                <span className="text-xl">{action.icon}</span>
+                <span className="text-sm font-medium">{action.label}</span>
+              </Link>
+            ))}
+          </div>
+
+          {/* Product stock list */}
+          <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-bold text-sm">在庫一覧</h3>
+              <Link
+                href="/sales/inventory/products"
+                className="text-xs text-accent hover:underline"
+              >
+                商品マスタ →
+              </Link>
+            </div>
+
+            <div className="space-y-2">
+              {items.map((item) => {
+                const isLow = item.current_stock <= item.reorder_point;
+                return (
+                  <div
+                    key={item.product_id}
+                    className={`flex items-center justify-between px-3 py-2.5 rounded-xl ${
+                      isLow ? "bg-amber-50 border border-amber-200" : "bg-background"
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">{item.product_name}</p>
+                      {item.category && (
+                        <p className="text-xs text-text-light">{item.category}</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0 ml-3">
+                      <div className="text-right">
+                        <p className={`text-sm font-bold ${isLow ? "text-amber-600" : ""}`}>
+                          {item.current_stock}個
+                        </p>
+                        <p className="text-[10px] text-text-light">
+                          発注点 {item.reorder_point}
+                        </p>
+                      </div>
+                      {isLow && (
+                        <span className="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full shrink-0">
+                          要発注
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/products/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/products/page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { Toast, useToast } from "@/components/ui/toast";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import type { Database } from "@/types/database";
+
+type Product = Database["public"]["Tables"]["products"]["Row"];
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [salonId, setSalonId] = useState("");
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const { toast, showToast, hideToast } = useToast();
+  const [form, setForm] = useState({
+    name: "",
+    category: "",
+    base_sell_price: "",
+    base_cost_price: "",
+    reorder_point: "3",
+    memo: "",
+  });
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const loadProducts = async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+
+    setSalonId(salon.id);
+
+    const { data } = await supabase
+      .from("products")
+      .select("*")
+      .eq("salon_id", salon.id)
+      .order("created_at", { ascending: true })
+      .returns<Product[]>();
+
+    setProducts(data ?? []);
+  };
+
+  const resetForm = () => {
+    setForm({
+      name: "",
+      category: "",
+      base_sell_price: "",
+      base_cost_price: "",
+      reorder_point: "3",
+      memo: "",
+    });
+    setShowForm(false);
+    setEditingId(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const supabase = createClient();
+    const payload = {
+      name: form.name,
+      category: form.category || null,
+      base_sell_price: form.base_sell_price ? parseInt(form.base_sell_price) : 0,
+      base_cost_price: form.base_cost_price ? parseInt(form.base_cost_price) : 0,
+      reorder_point: form.reorder_point ? parseInt(form.reorder_point) : 3,
+      memo: form.memo || null,
+    };
+
+    if (editingId) {
+      const { error } = await supabase
+        .from("products")
+        .update(payload)
+        .eq("id", editingId);
+      if (error) {
+        setError("商品の更新に失敗しました");
+        setLoading(false);
+        return;
+      }
+    } else {
+      const { error } = await supabase
+        .from("products")
+        .insert({ ...payload, salon_id: salonId });
+      if (error) {
+        setError("商品の追加に失敗しました");
+        setLoading(false);
+        return;
+      }
+    }
+
+    setLoading(false);
+    resetForm();
+    showToast(editingId ? "商品を更新しました" : "商品を追加しました");
+    loadProducts();
+  };
+
+  const startEdit = (product: Product) => {
+    setForm({
+      name: product.name,
+      category: product.category ?? "",
+      base_sell_price: product.base_sell_price?.toString() ?? "",
+      base_cost_price: product.base_cost_price?.toString() ?? "",
+      reorder_point: product.reorder_point?.toString() ?? "3",
+      memo: product.memo ?? "",
+    });
+    setEditingId(product.id);
+    setShowForm(true);
+  };
+
+  const handleToggleActive = async (productId: string, currentActive: boolean) => {
+    setError("");
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("products")
+      .update({ is_active: !currentActive })
+      .eq("id", productId);
+    if (error) {
+      setError("ステータスの変更に失敗しました");
+      return;
+    }
+    loadProducts();
+  };
+
+  const handleDelete = async (productId: string) => {
+    if (!confirm("この商品を削除しますか？在庫ログも削除されます。")) return;
+    setError("");
+    const supabase = createClient();
+    const { error } = await supabase.from("products").delete().eq("id", productId);
+    if (error) {
+      setError("商品の削除に失敗しました。在庫ログがある場合は非表示にしてください。");
+      return;
+    }
+    loadProducts();
+  };
+
+  const inputClass =
+    "w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors";
+
+  return (
+    <div className="space-y-4">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={hideToast} />}
+      <PageHeader
+        title="商品マスタ"
+        backLabel="在庫管理"
+        backHref="/sales/inventory"
+        breadcrumbs={[
+          { label: "経営", href: "/sales" },
+          { label: "在庫管理", href: "/sales/inventory" },
+          { label: "商品マスタ" },
+        ]}
+      >
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[40px]"
+          >
+            + 追加
+          </button>
+        )}
+      </PageHeader>
+
+      {error && <ErrorAlert message={error} />}
+
+      {/* Form */}
+      {showForm && (
+        <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-2xl p-5 space-y-4">
+          <h3 className="font-bold">
+            {editingId ? "商品を編集" : "商品を追加"}
+          </h3>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              商品名 <span className="text-error">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              required
+              placeholder="例: モイスチャー美容液"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              カテゴリ
+            </label>
+            <input
+              type="text"
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              placeholder="例: スキンケア、ヘアケア"
+              className={inputClass}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium mb-1.5">
+                売価（円）
+              </label>
+              <input
+                type="number"
+                value={form.base_sell_price}
+                onChange={(e) => setForm({ ...form, base_sell_price: e.target.value })}
+                placeholder="5000"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">
+                仕入価（円）
+              </label>
+              <input
+                type="number"
+                value={form.base_cost_price}
+                onChange={(e) => setForm({ ...form, base_cost_price: e.target.value })}
+                placeholder="2500"
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              発注点（残りこの数以下で通知）
+            </label>
+            <input
+              type="number"
+              value={form.reorder_point}
+              onChange={(e) => setForm({ ...form, reorder_point: e.target.value })}
+              placeholder="3"
+              min="0"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">メモ</label>
+            <textarea
+              value={form.memo}
+              onChange={(e) => setForm({ ...form, memo: e.target.value })}
+              placeholder="仕入先など自由メモ"
+              rows={2}
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="flex-1 bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors disabled:opacity-50 min-h-[48px]"
+            >
+              {loading ? "保存中..." : editingId ? "更新する" : "追加する"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Product list */}
+      {products.length > 0 ? (
+        <div className="space-y-2">
+          {products.map((product) => (
+            <div
+              key={product.id}
+              className={`bg-surface border rounded-xl p-4 ${product.is_active ? "border-border" : "border-border opacity-60"}`}
+            >
+              <div className="flex justify-between items-start">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium">{product.name}</p>
+                    {!product.is_active && (
+                      <span className="text-[10px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded-full shrink-0">非表示</span>
+                    )}
+                  </div>
+                  <div className="flex gap-3 mt-1 text-sm text-text-light flex-wrap">
+                    {product.category && <span>{product.category}</span>}
+                    <span>売価 ¥{product.base_sell_price.toLocaleString()}</span>
+                    <span>仕入 ¥{product.base_cost_price.toLocaleString()}</span>
+                    <span>発注点 {product.reorder_point}個</span>
+                  </div>
+                  {product.memo && (
+                    <p className="text-xs text-text-light mt-1">{product.memo}</p>
+                  )}
+                </div>
+                <div className="flex items-center gap-3 shrink-0 ml-3">
+                  <button
+                    onClick={() => handleToggleActive(product.id, product.is_active)}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${product.is_active ? "bg-accent" : "bg-gray-200"}`}
+                    aria-label={product.is_active ? "非表示にする" : "表示にする"}
+                  >
+                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${product.is_active ? "translate-x-6" : "translate-x-1"}`} />
+                  </button>
+                  <button
+                    onClick={() => startEdit(product)}
+                    className="text-sm text-accent hover:underline"
+                  >
+                    編集
+                  </button>
+                  <button
+                    onClick={() => handleDelete(product.id)}
+                    className="text-sm text-error hover:underline"
+                  >
+                    削除
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        !showForm && (
+          <div className="bg-surface border border-border rounded-xl p-6 text-center">
+            <p className="text-text-light">商品が登録されていません</p>
+            <button
+              onClick={() => setShowForm(true)}
+              className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
+            >
+              最初の商品を追加する →
+            </button>
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/receive/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/receive/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import type { Database } from "@/types/database";
+
+type Product = Database["public"]["Tables"]["products"]["Row"];
+
+export default function ReceivePage() {
+  const router = useRouter();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [salonId, setSalonId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const today = (() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  })();
+
+  const [form, setForm] = useState({
+    product_id: "",
+    quantity: "1",
+    unit_cost_price: "",
+    logged_at: today,
+  });
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const loadProducts = async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+    setSalonId(salon.id);
+
+    const { data } = await supabase
+      .from("products")
+      .select("*")
+      .eq("salon_id", salon.id)
+      .eq("is_active", true)
+      .order("name")
+      .returns<Product[]>();
+
+    setProducts(data ?? []);
+  };
+
+  // 商品選択時にデフォルトの仕入単価をセット
+  const handleProductChange = (productId: string) => {
+    setForm((prev) => {
+      const product = products.find((p) => p.id === productId);
+      return {
+        ...prev,
+        product_id: productId,
+        unit_cost_price: product ? product.base_cost_price.toString() : "",
+      };
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.product_id) {
+      setError("商品を選択してください");
+      return;
+    }
+    setError("");
+    setSuccess("");
+    setLoading(true);
+
+    const supabase = createClient();
+    const quantity = parseInt(form.quantity) || 1;
+    const unitCostPrice = form.unit_cost_price ? parseInt(form.unit_cost_price) : 0;
+
+    const { error: insertError } = await supabase.from("inventory_logs").insert({
+      salon_id: salonId,
+      product_id: form.product_id,
+      log_type: "purchase_in",
+      quantity: quantity, // 入庫は正数
+      unit_cost_price: unitCostPrice,
+      logged_at: form.logged_at,
+    });
+
+    if (insertError) {
+      setError("仕入記録の登録に失敗しました");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+    const product = products.find((p) => p.id === form.product_id);
+    setSuccess(`${product?.name ?? "商品"} を ${quantity}個 入庫しました`);
+
+    // フォームリセット（日付はそのまま）
+    setForm({
+      product_id: "",
+      quantity: "1",
+      unit_cost_price: "",
+      logged_at: form.logged_at,
+    });
+  };
+
+  const inputClass =
+    "w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors";
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="仕入記録"
+        backLabel="在庫管理"
+        backHref="/sales/inventory"
+        breadcrumbs={[
+          { label: "経営", href: "/sales" },
+          { label: "在庫管理", href: "/sales/inventory" },
+          { label: "仕入記録" },
+        ]}
+      />
+
+      {error && <ErrorAlert message={error} />}
+
+      {success && (
+        <div className="bg-green-50 text-green-700 text-sm rounded-xl px-4 py-3 flex items-center justify-between">
+          <span>{success}</span>
+          <button
+            type="button"
+            onClick={() => setSuccess("")}
+            className="text-xs underline"
+          >
+            閉じる
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-2xl p-5 space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1.5">
+            商品 <span className="text-error">*</span>
+          </label>
+          <select
+            value={form.product_id}
+            onChange={(e) => handleProductChange(e.target.value)}
+            required
+            className={inputClass}
+          >
+            <option value="">商品を選択</option>
+            {products.map((product) => (
+              <option key={product.id} value={product.id}>
+                {product.name}
+                {product.category ? ` (${product.category})` : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              数量 <span className="text-error">*</span>
+            </label>
+            <input
+              type="number"
+              value={form.quantity}
+              onChange={(e) => setForm({ ...form, quantity: e.target.value })}
+              required
+              min="1"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1.5">
+              仕入単価（円）
+            </label>
+            <input
+              type="number"
+              value={form.unit_cost_price}
+              onChange={(e) => setForm({ ...form, unit_cost_price: e.target.value })}
+              placeholder="自動入力"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1.5">仕入日</label>
+          <input
+            type="date"
+            value={form.logged_at}
+            onChange={(e) => setForm({ ...form, logged_at: e.target.value })}
+            required
+            className={inputClass}
+          />
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="flex-1 bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
+          >
+            戻る
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex-1 bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors disabled:opacity-50 min-h-[48px]"
+          >
+            {loading ? "記録中..." : "入庫を記録"}
+          </button>
+        </div>
+      </form>
+
+      {products.length === 0 && (
+        <div className="text-center text-text-light text-sm py-4">
+          商品が登録されていません。先に
+          <a href="/sales/inventory/products" className="text-accent hover:underline">商品マスタ</a>
+          から登録してください。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/stocktake/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/stocktake/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ErrorAlert } from "@/components/ui/error-alert";
+
+type InventoryItem = {
+  product_id: string;
+  product_name: string;
+  category: string | null;
+  current_stock: number;
+};
+
+type StocktakeEntry = {
+  product_id: string;
+  product_name: string;
+  category: string | null;
+  system_stock: number;
+  actual_stock: string;
+};
+
+export default function StocktakePage() {
+  const router = useRouter();
+  const [entries, setEntries] = useState<StocktakeEntry[]>([]);
+  const [salonId, setSalonId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  useEffect(() => {
+    loadInventory();
+  }, []);
+
+  const loadInventory = async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+    setSalonId(salon.id);
+
+    const { data } = await supabase.rpc("get_inventory_summary", {
+      p_salon_id: salon.id,
+    });
+
+    const items = (data as InventoryItem[]) ?? [];
+    setEntries(
+      items.map((item) => ({
+        product_id: item.product_id,
+        product_name: item.product_name,
+        category: item.category,
+        system_stock: item.current_stock,
+        actual_stock: item.current_stock.toString(),
+      }))
+    );
+    setLoading(false);
+  };
+
+  const updateActualStock = (productId: string, value: string) => {
+    setEntries((prev) =>
+      prev.map((e) =>
+        e.product_id === productId ? { ...e, actual_stock: value } : e
+      )
+    );
+  };
+
+  // 差分がある商品のみ
+  const diffs = entries.filter((e) => {
+    const actual = parseInt(e.actual_stock, 10);
+    return !isNaN(actual) && actual !== e.system_stock;
+  });
+
+  const handleSubmit = async () => {
+    if (diffs.length === 0) {
+      setError("差分がありません");
+      return;
+    }
+    setError("");
+    setSuccess("");
+    setSaving(true);
+
+    const supabase = createClient();
+    const now = new Date();
+    const reason = `${now.getFullYear()}年${now.getMonth() + 1}月 棚卸し調整`;
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+    const logs = diffs.map((entry) => {
+      const actual = parseInt(entry.actual_stock, 10);
+      const diff = actual - entry.system_stock;
+      return {
+        salon_id: salonId,
+        product_id: entry.product_id,
+        log_type: "adjust" as const,
+        quantity: diff, // 正=増加、負=減少
+        reason,
+        logged_at: today,
+      };
+    });
+
+    const { error: insertError } = await supabase
+      .from("inventory_logs")
+      .insert(logs);
+
+    if (insertError) {
+      setError("棚卸し調整の登録に失敗しました");
+      setSaving(false);
+      return;
+    }
+
+    setSaving(false);
+    setSuccess(`${diffs.length}商品の在庫を調整しました`);
+
+    // 再読み込みで最新の在庫を反映
+    setLoading(true);
+    await loadInventory();
+  };
+
+  const inputClass =
+    "w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors text-center";
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="棚卸し"
+        backLabel="在庫管理"
+        backHref="/sales/inventory"
+        breadcrumbs={[
+          { label: "経営", href: "/sales" },
+          { label: "在庫管理", href: "/sales/inventory" },
+          { label: "棚卸し" },
+        ]}
+      />
+
+      {error && <ErrorAlert message={error} />}
+
+      {success && (
+        <div className="bg-green-50 text-green-700 text-sm rounded-xl px-4 py-3 flex items-center justify-between">
+          <span>{success}</span>
+          <button
+            type="button"
+            onClick={() => setSuccess("")}
+            className="text-xs underline"
+          >
+            閉じる
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="bg-surface border border-border rounded-2xl p-4 animate-pulse space-y-3">
+          <div className="h-4 bg-border rounded w-24" />
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 bg-border rounded-xl" />
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="bg-surface border border-border rounded-xl p-6 text-center text-text-light">
+          <p>アクティブな商品がありません</p>
+          <a
+            href="/sales/inventory/products"
+            className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
+          >
+            商品を登録する →
+          </a>
+        </div>
+      ) : (
+        <>
+          <div className="bg-surface border border-border rounded-2xl p-4 space-y-1">
+            <p className="text-sm text-text-light mb-3">
+              各商品の実在庫を入力してください。差分がある場合に調整ログが作成されます。
+            </p>
+
+            {/* Header */}
+            <div className="grid grid-cols-[1fr_80px_80px_60px] gap-2 text-xs text-text-light font-medium px-1 pb-2 border-b border-border">
+              <span>商品</span>
+              <span className="text-center">システム</span>
+              <span className="text-center">実在庫</span>
+              <span className="text-center">差分</span>
+            </div>
+
+            {/* Entries */}
+            {entries.map((entry) => {
+              const actual = parseInt(entry.actual_stock, 10);
+              const diff = isNaN(actual) ? 0 : actual - entry.system_stock;
+              const hasDiff = !isNaN(actual) && diff !== 0;
+
+              return (
+                <div
+                  key={entry.product_id}
+                  className={`grid grid-cols-[1fr_80px_80px_60px] gap-2 items-center py-2 px-1 rounded-lg ${
+                    hasDiff ? "bg-amber-50" : ""
+                  }`}
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">{entry.product_name}</p>
+                    {entry.category && (
+                      <p className="text-xs text-text-light truncate">{entry.category}</p>
+                    )}
+                  </div>
+                  <p className="text-sm text-center text-text-light tabular-nums">
+                    {entry.system_stock}
+                  </p>
+                  <input
+                    type="number"
+                    value={entry.actual_stock}
+                    onChange={(e) => updateActualStock(entry.product_id, e.target.value)}
+                    min="0"
+                    className={`${inputClass} text-sm py-2`}
+                  />
+                  <p
+                    className={`text-sm text-center font-bold tabular-nums ${
+                      diff > 0 ? "text-green-600" : diff < 0 ? "text-red-500" : "text-text-light"
+                    }`}
+                  >
+                    {hasDiff ? (diff > 0 ? `+${diff}` : diff) : "—"}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Summary & Submit */}
+          <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">
+                差分がある商品: <span className="text-accent font-bold">{diffs.length}件</span>
+              </span>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => router.back()}
+                className="flex-1 bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
+              >
+                戻る
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={saving || diffs.length === 0}
+                className="flex-1 bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors disabled:opacity-50 min-h-[48px]"
+              >
+                {saving ? "処理中..." : "棚卸しを確定"}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/inventory/tax-report/page.tsx
+++ b/src/app/(dashboard)/sales/inventory/tax-report/page.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+
+type TaxReportData = {
+  year: number;
+  opening_stock_value: number;
+  closing_stock_value: number;
+  total_purchases: number;
+  cost_of_goods_sold: number;
+  monthly_purchases: { month: number; amount: number }[];
+  closing_stock_details: {
+    product_name: string;
+    stock: number;
+    unit_price: number;
+    total_value: number;
+  }[];
+};
+
+type MonthlySales = {
+  month: number;
+  treatment_sales: number;
+  product_sales: number;
+  ticket_sales: number;
+};
+
+function formatYen(amount: number): string {
+  return `¥${amount.toLocaleString()}`;
+}
+
+type CsvFormat = "generic" | "freee" | "yayoi";
+
+export default function TaxReportPage() {
+  const [report, setReport] = useState<TaxReportData | null>(null);
+  const [monthlySales, setMonthlySales] = useState<MonthlySales[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [year, setYear] = useState(new Date().getFullYear());
+
+  const loadReport = useCallback(async (targetYear: number) => {
+    setLoading(true);
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data: salon } = await supabase
+      .from("salons")
+      .select("id")
+      .eq("owner_id", user.id)
+      .single<{ id: string }>();
+    if (!salon) return;
+
+    // 在庫レポートと売上データを並列取得
+    const [taxRes, salesRes] = await Promise.all([
+      supabase.rpc("get_tax_report", {
+        p_salon_id: salon.id,
+        p_year: targetYear,
+      }),
+      supabase.rpc("get_monthly_sales_summary", {
+        p_salon_id: salon.id,
+        p_year: targetYear,
+      }),
+    ]);
+
+    if (taxRes.data) {
+      setReport(taxRes.data as unknown as TaxReportData);
+    }
+    setMonthlySales((salesRes.data as MonthlySales[]) ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadReport(year);
+  }, [year, loadReport]);
+
+  const currentYear = new Date().getFullYear();
+
+  // 年間売上合計
+  const totalTreatmentSales = monthlySales.reduce((s, m) => s + m.treatment_sales, 0);
+  const totalProductSales = monthlySales.reduce((s, m) => s + m.product_sales, 0);
+  const totalTicketSales = monthlySales.reduce((s, m) => s + m.ticket_sales, 0);
+  const totalSales = totalTreatmentSales + totalProductSales + totalTicketSales;
+
+  // CSV生成
+  const downloadCsv = (format: CsvFormat) => {
+    if (!report) return;
+
+    let csvContent = "";
+    const bom = "\uFEFF"; // UTF-8 BOM for Excel
+
+    if (format === "generic") {
+      csvContent = generateGenericCsv(report, monthlySales, year);
+    } else if (format === "freee") {
+      csvContent = generateFreeeCsv(report, monthlySales, year);
+    } else if (format === "yayoi") {
+      csvContent = generateYayoiCsv(report, monthlySales, year);
+    }
+
+    const blob = new Blob([bom + csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `確定申告_${year}年_${format}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="確定申告レポート"
+        backLabel="在庫管理"
+        backHref="/sales/inventory"
+        breadcrumbs={[
+          { label: "経営", href: "/sales" },
+          { label: "在庫管理", href: "/sales/inventory" },
+          { label: "確定申告レポート" },
+        ]}
+      />
+
+      {/* Year navigation */}
+      <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
+        <button
+          onClick={() => setYear((y) => y - 1)}
+          className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+          </svg>
+        </button>
+        <span className="font-bold text-lg">{year}年</span>
+        <button
+          onClick={() => setYear((y) => y + 1)}
+          disabled={year >= currentYear}
+          className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center disabled:opacity-30"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-surface border border-border rounded-2xl p-5 animate-pulse">
+              <div className="h-4 bg-border rounded w-32 mb-3" />
+              <div className="h-8 bg-border rounded w-48" />
+            </div>
+          ))}
+        </div>
+      ) : !report ? (
+        <div className="bg-surface border border-border rounded-xl p-6 text-center text-text-light">
+          データがありません
+        </div>
+      ) : (
+        <>
+          {/* 売上原価計算 */}
+          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+            <h3 className="font-bold text-sm">売上原価の計算</h3>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-text-light">期首棚卸高</span>
+                <span className="font-medium tabular-nums">{formatYen(report.opening_stock_value)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-text-light">＋ 当期仕入高</span>
+                <span className="font-medium tabular-nums">{formatYen(report.total_purchases)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-text-light">− 期末棚卸高</span>
+                <span className="font-medium tabular-nums">{formatYen(report.closing_stock_value)}</span>
+              </div>
+              <div className="border-t border-border pt-2 flex justify-between">
+                <span className="font-bold text-sm">＝ 売上原価</span>
+                <span className="font-bold text-lg text-accent tabular-nums">
+                  {formatYen(report.cost_of_goods_sold)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 粗利サマリー */}
+          <div className="bg-accent/5 border border-accent/20 rounded-2xl p-5 space-y-2">
+            <h3 className="font-bold text-sm">粗利サマリー</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs text-text-light">年間売上合計</p>
+                <p className="text-lg font-bold tabular-nums">{formatYen(totalSales)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-text-light">売上原価</p>
+                <p className="text-lg font-bold tabular-nums">{formatYen(report.cost_of_goods_sold)}</p>
+              </div>
+            </div>
+            <div className="border-t border-accent/20 pt-2">
+              <p className="text-xs text-text-light">粗利</p>
+              <p className="text-xl font-bold text-accent tabular-nums">
+                {formatYen(totalSales - report.cost_of_goods_sold)}
+              </p>
+            </div>
+          </div>
+
+          {/* 月別売上 */}
+          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+            <h3 className="font-bold text-sm">月別売上</h3>
+            {monthlySales.length === 0 ? (
+              <p className="text-sm text-text-light text-center py-2">データなし</p>
+            ) : (
+              <div className="space-y-1">
+                <div className="grid grid-cols-[40px_1fr_1fr_1fr_1fr] gap-1 text-[10px] text-text-light font-medium pb-1 border-b border-border">
+                  <span></span>
+                  <span className="text-right">施術</span>
+                  <span className="text-right">物販</span>
+                  <span className="text-right">回数券</span>
+                  <span className="text-right font-bold">計</span>
+                </div>
+                {monthlySales.map((m) => {
+                  const total = m.treatment_sales + m.product_sales + m.ticket_sales;
+                  return (
+                    <div key={m.month} className="grid grid-cols-[40px_1fr_1fr_1fr_1fr] gap-1 text-xs tabular-nums py-1">
+                      <span className="text-text-light font-medium">{m.month}月</span>
+                      <span className="text-right">{m.treatment_sales.toLocaleString()}</span>
+                      <span className="text-right">{m.product_sales.toLocaleString()}</span>
+                      <span className="text-right">{m.ticket_sales.toLocaleString()}</span>
+                      <span className="text-right font-bold">{total.toLocaleString()}</span>
+                    </div>
+                  );
+                })}
+                <div className="grid grid-cols-[40px_1fr_1fr_1fr_1fr] gap-1 text-xs tabular-nums pt-1 border-t border-border font-bold">
+                  <span>合計</span>
+                  <span className="text-right">{totalTreatmentSales.toLocaleString()}</span>
+                  <span className="text-right">{totalProductSales.toLocaleString()}</span>
+                  <span className="text-right">{totalTicketSales.toLocaleString()}</span>
+                  <span className="text-right text-accent">{totalSales.toLocaleString()}</span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* 月別仕入 */}
+          {report.monthly_purchases.length > 0 && (
+            <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+              <h3 className="font-bold text-sm">月別仕入金額</h3>
+              <div className="space-y-1">
+                {report.monthly_purchases.map((mp) => (
+                  <div key={mp.month} className="flex justify-between text-sm">
+                    <span className="text-text-light">{mp.month}月</span>
+                    <span className="font-medium tabular-nums">{formatYen(mp.amount)}</span>
+                  </div>
+                ))}
+                <div className="flex justify-between text-sm border-t border-border pt-1 font-bold">
+                  <span>合計</span>
+                  <span className="tabular-nums">{formatYen(report.total_purchases)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 期末棚卸明細 */}
+          {report.closing_stock_details.length > 0 && (
+            <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+              <h3 className="font-bold text-sm">期末棚卸明細</h3>
+              <div className="space-y-1">
+                <div className="grid grid-cols-[1fr_50px_70px_80px] gap-1 text-[10px] text-text-light font-medium pb-1 border-b border-border">
+                  <span>商品名</span>
+                  <span className="text-right">在庫</span>
+                  <span className="text-right">単価</span>
+                  <span className="text-right">金額</span>
+                </div>
+                {report.closing_stock_details.map((item, i) => (
+                  <div key={i} className="grid grid-cols-[1fr_50px_70px_80px] gap-1 text-xs tabular-nums py-1">
+                    <span className="truncate">{item.product_name}</span>
+                    <span className="text-right">{item.stock}</span>
+                    <span className="text-right">{item.unit_price.toLocaleString()}</span>
+                    <span className="text-right font-medium">{item.total_value.toLocaleString()}</span>
+                  </div>
+                ))}
+                <div className="flex justify-between text-sm border-t border-border pt-1 font-bold">
+                  <span>期末棚卸高 合計</span>
+                  <span className="tabular-nums">{formatYen(report.closing_stock_value)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* CSV出力 */}
+          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+            <h3 className="font-bold text-sm">CSV出力</h3>
+            <p className="text-xs text-text-light">
+              確定申告用のデータをCSV形式でダウンロードできます
+            </p>
+            <div className="space-y-2">
+              <button
+                onClick={() => downloadCsv("generic")}
+                className="w-full bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors min-h-[48px] text-sm"
+              >
+                汎用CSV ダウンロード
+              </button>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  onClick={() => downloadCsv("freee")}
+                  className="bg-background border border-border text-text font-medium rounded-xl py-2.5 transition-colors min-h-[44px] text-sm hover:bg-border/30"
+                >
+                  freee形式
+                </button>
+                <button
+                  onClick={() => downloadCsv("yayoi")}
+                  className="bg-background border border-border text-text font-medium rounded-xl py-2.5 transition-colors min-h-[44px] text-sm hover:bg-border/30"
+                >
+                  弥生形式
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- CSV Generator Functions ---
+
+function generateGenericCsv(
+  report: TaxReportData,
+  monthlySales: MonthlySales[],
+  year: number
+): string {
+  const lines: string[] = [];
+
+  lines.push(`${year}年 確定申告レポート`);
+  lines.push("");
+
+  // 売上原価
+  lines.push("【売上原価】");
+  lines.push("項目,金額");
+  lines.push(`期首棚卸高,${report.opening_stock_value}`);
+  lines.push(`当期仕入高,${report.total_purchases}`);
+  lines.push(`期末棚卸高,${report.closing_stock_value}`);
+  lines.push(`売上原価,${report.cost_of_goods_sold}`);
+  lines.push("");
+
+  // 月別売上
+  lines.push("【月別売上】");
+  lines.push("月,施術,物販,回数券,合計");
+  for (const m of monthlySales) {
+    const total = m.treatment_sales + m.product_sales + m.ticket_sales;
+    lines.push(`${m.month},${m.treatment_sales},${m.product_sales},${m.ticket_sales},${total}`);
+  }
+  lines.push("");
+
+  // 月別仕入
+  if (report.monthly_purchases.length > 0) {
+    lines.push("【月別仕入】");
+    lines.push("月,仕入金額");
+    for (const mp of report.monthly_purchases) {
+      lines.push(`${mp.month},${mp.amount}`);
+    }
+    lines.push("");
+  }
+
+  // 期末棚卸明細
+  if (report.closing_stock_details.length > 0) {
+    lines.push("【期末棚卸明細】");
+    lines.push("商品名,在庫数,仕入単価,金額");
+    for (const item of report.closing_stock_details) {
+      lines.push(`"${item.product_name}",${item.stock},${item.unit_price},${item.total_value}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function generateFreeeCsv(
+  report: TaxReportData,
+  monthlySales: MonthlySales[],
+  year: number
+): string {
+  // freee取り込み形式: 日付, 勘定科目, 金額, 摘要
+  const lines: string[] = [];
+  lines.push("取引日,勘定科目,税区分,金額,摘要");
+
+  // 月別売上
+  for (const m of monthlySales) {
+    const date = `${year}/${String(m.month).padStart(2, "0")}/01`;
+    if (m.treatment_sales > 0) {
+      lines.push(`${date},売上高,課税売上10%,${m.treatment_sales},施術売上 ${m.month}月分`);
+    }
+    if (m.product_sales > 0) {
+      lines.push(`${date},売上高,課税売上10%,${m.product_sales},物販売上 ${m.month}月分`);
+    }
+    if (m.ticket_sales > 0) {
+      lines.push(`${date},売上高,課税売上10%,${m.ticket_sales},回数券売上 ${m.month}月分`);
+    }
+  }
+
+  // 月別仕入
+  for (const mp of report.monthly_purchases) {
+    const date = `${year}/${String(mp.month).padStart(2, "0")}/01`;
+    lines.push(`${date},仕入高,課対仕入10%,${mp.amount},商品仕入 ${mp.month}月分`);
+  }
+
+  return lines.join("\n");
+}
+
+function generateYayoiCsv(
+  report: TaxReportData,
+  monthlySales: MonthlySales[],
+  year: number
+): string {
+  // 弥生形式: 仕訳日付, 借方勘定科目, 借方金額, 貸方勘定科目, 貸方金額, 摘要
+  const lines: string[] = [];
+  lines.push("仕訳日付,借方勘定科目,借方金額,貸方勘定科目,貸方金額,摘要");
+
+  // 月別売上
+  for (const m of monthlySales) {
+    const total = m.treatment_sales + m.product_sales + m.ticket_sales;
+    if (total > 0) {
+      const date = `${year}/${String(m.month).padStart(2, "0")}/01`;
+      lines.push(`${date},売掛金,${total},売上高,${total},${m.month}月 売上合計`);
+    }
+  }
+
+  // 月別仕入
+  for (const mp of report.monthly_purchases) {
+    const date = `${year}/${String(mp.month).padStart(2, "0")}/01`;
+    lines.push(`${date},仕入高,${mp.amount},買掛金,${mp.amount},${mp.month}月 商品仕入`);
+  }
+
+  // 期末棚卸
+  if (report.closing_stock_value > 0) {
+    lines.push(`${year}/12/31,商品,${report.closing_stock_value},期末商品棚卸高,${report.closing_stock_value},期末棚卸`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/app/(dashboard)/sales/page.tsx
+++ b/src/app/(dashboard)/sales/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { ManagementTabs } from "@/components/inventory/management-tabs";
 
 type MonthlySales = {
   month: number;
@@ -191,6 +192,7 @@ export default function SalesPage() {
 
   return (
     <div className="space-y-4">
+      <ManagementTabs />
       <h2 className="text-xl font-bold">売上レポート</h2>
 
       {/* Year navigation */}

--- a/src/components/inventory/management-tabs.tsx
+++ b/src/components/inventory/management-tabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/sales", label: "売上レポート", exact: true },
+  { href: "/sales/inventory", label: "在庫管理", exact: false },
+];
+
+export function ManagementTabs() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex gap-1.5 bg-background rounded-xl p-1">
+      {tabs.map((tab) => {
+        const isActive = tab.exact
+          ? pathname === tab.href
+          : pathname.startsWith(tab.href);
+
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`flex-1 text-center text-sm font-medium py-2.5 rounded-lg transition-colors min-h-[44px] flex items-center justify-center ${
+              isActive
+                ? "bg-accent text-white shadow-sm"
+                : "text-text-light hover:text-text"
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/dashboard-header.tsx
+++ b/src/components/layout/dashboard-header.tsx
@@ -9,7 +9,7 @@ const navItems = [
   { href: "/appointments", label: "予約", icon: "calendar" },
   // FAB goes here (rendered separately)
   { href: "/customers", label: "顧客", icon: "customers" },
-  { href: "/sales", label: "売上", icon: "sales" },
+  { href: "/sales", label: "経営", icon: "sales" },
 ];
 
 const fabActions = [

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -424,6 +424,9 @@ export type Database = {
           unit_price: number;
           total_price: number;
           memo: string | null;
+          product_id: string | null;
+          cost_price: number | null;
+          sell_price: number | null;
           created_at: string;
           updated_at: string;
         };
@@ -437,6 +440,9 @@ export type Database = {
           unit_price?: number;
           total_price?: number;
           memo?: string | null;
+          product_id?: string | null;
+          cost_price?: number | null;
+          sell_price?: number | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -450,6 +456,9 @@ export type Database = {
           unit_price?: number;
           total_price?: number;
           memo?: string | null;
+          product_id?: string | null;
+          cost_price?: number | null;
+          sell_price?: number | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -466,6 +475,127 @@ export type Database = {
             columns: ["customer_id"];
             isOneToOne: false;
             referencedRelation: "customers";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "purchases_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      products: {
+        Row: {
+          id: string;
+          salon_id: string;
+          name: string;
+          category: string | null;
+          base_sell_price: number;
+          base_cost_price: number;
+          reorder_point: number;
+          is_active: boolean;
+          memo: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          salon_id: string;
+          name: string;
+          category?: string | null;
+          base_sell_price?: number;
+          base_cost_price?: number;
+          reorder_point?: number;
+          is_active?: boolean;
+          memo?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          salon_id?: string;
+          name?: string;
+          category?: string | null;
+          base_sell_price?: number;
+          base_cost_price?: number;
+          reorder_point?: number;
+          is_active?: boolean;
+          memo?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "products_salon_id_fkey";
+            columns: ["salon_id"];
+            isOneToOne: false;
+            referencedRelation: "salons";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      inventory_logs: {
+        Row: {
+          id: string;
+          salon_id: string;
+          product_id: string;
+          log_type: string;
+          quantity: number;
+          unit_cost_price: number | null;
+          unit_sell_price: number | null;
+          reason: string | null;
+          related_purchase_id: string | null;
+          logged_at: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          salon_id: string;
+          product_id: string;
+          log_type: string;
+          quantity: number;
+          unit_cost_price?: number | null;
+          unit_sell_price?: number | null;
+          reason?: string | null;
+          related_purchase_id?: string | null;
+          logged_at?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          salon_id?: string;
+          product_id?: string;
+          log_type?: string;
+          quantity?: number;
+          unit_cost_price?: number | null;
+          unit_sell_price?: number | null;
+          reason?: string | null;
+          related_purchase_id?: string | null;
+          logged_at?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "inventory_logs_salon_id_fkey";
+            columns: ["salon_id"];
+            isOneToOne: false;
+            referencedRelation: "salons";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "inventory_logs_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "inventory_logs_related_purchase_id_fkey";
+            columns: ["related_purchase_id"];
+            isOneToOne: false;
+            referencedRelation: "purchases";
             referencedColumns: ["id"];
           },
         ];
@@ -568,6 +698,57 @@ export type Database = {
         Returns: {
           used_sessions: number;
           status: string;
+        };
+      };
+      get_inventory_summary: {
+        Args: {
+          p_salon_id: string;
+        };
+        Returns: {
+          product_id: string;
+          product_name: string;
+          category: string | null;
+          base_sell_price: number;
+          base_cost_price: number;
+          reorder_point: number;
+          is_active: boolean;
+          current_stock: number;
+          stock_value: number;
+        }[];
+      };
+      record_product_sale: {
+        Args: {
+          p_salon_id: string;
+          p_customer_id: string;
+          p_product_id: string;
+          p_quantity: number;
+          p_sell_price: number;
+          p_purchase_date?: string;
+          p_memo?: string | null;
+        };
+        Returns: {
+          purchase_id: string;
+          remaining_stock: number;
+        };
+      };
+      get_tax_report: {
+        Args: {
+          p_salon_id: string;
+          p_year: number;
+        };
+        Returns: {
+          year: number;
+          opening_stock_value: number;
+          closing_stock_value: number;
+          total_purchases: number;
+          cost_of_goods_sold: number;
+          monthly_purchases: { month: number; amount: number }[];
+          closing_stock_details: {
+            product_name: string;
+            stock: number;
+            unit_price: number;
+            total_value: number;
+          }[];
         };
       };
     };

--- a/supabase/migrations/00012_inventory_management.sql
+++ b/supabase/migrations/00012_inventory_management.sql
@@ -1,0 +1,320 @@
+-- ========================================
+-- 在庫管理マイグレーション
+-- 商品マスタ・在庫ログ・RPC関数
+-- ========================================
+
+-- ----------------------------------------
+-- 1. products テーブル（商品マスタ）
+-- ----------------------------------------
+CREATE TABLE products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  salon_id UUID NOT NULL REFERENCES salons(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  category TEXT,
+  base_sell_price INTEGER NOT NULL DEFAULT 0,
+  base_cost_price INTEGER NOT NULL DEFAULT 0,
+  reorder_point INTEGER NOT NULL DEFAULT 3,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  memo TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- インデックス
+CREATE INDEX idx_products_salon_id ON products(salon_id);
+CREATE INDEX idx_products_active ON products(salon_id, is_active);
+
+-- updated_atトリガー
+CREATE TRIGGER update_products_updated_at
+  BEFORE UPDATE ON products
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- RLS
+ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Salon owners can manage their products"
+  ON products FOR ALL
+  USING (
+    salon_id IN (
+      SELECT id FROM salons WHERE owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    salon_id IN (
+      SELECT id FROM salons WHERE owner_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------
+-- 2. inventory_logs テーブル（入出庫ログ）
+-- ----------------------------------------
+CREATE TABLE inventory_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  salon_id UUID NOT NULL REFERENCES salons(id) ON DELETE CASCADE,
+  product_id UUID NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  log_type TEXT NOT NULL CHECK (log_type IN (
+    'purchase_in',   -- 仕入入庫
+    'sale_out',      -- 物販出庫
+    'sample_out',    -- サンプル消費
+    'waste_out',     -- 廃棄
+    'adjust',        -- 棚卸し調整
+    'return_in'      -- 返品入庫
+  )),
+  quantity INTEGER NOT NULL,  -- 正数=入庫、負数=出庫
+  unit_cost_price INTEGER,    -- 仕入単価（入庫時）
+  unit_sell_price INTEGER,    -- 売価（出庫時）
+  reason TEXT,                -- 調整理由メモ
+  related_purchase_id UUID REFERENCES purchases(id) ON DELETE SET NULL,
+  logged_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- インデックス
+CREATE INDEX idx_inventory_logs_salon_id ON inventory_logs(salon_id);
+CREATE INDEX idx_inventory_logs_product_id ON inventory_logs(product_id);
+CREATE INDEX idx_inventory_logs_logged_at ON inventory_logs(logged_at);
+CREATE INDEX idx_inventory_logs_type ON inventory_logs(salon_id, log_type);
+
+-- RLS
+ALTER TABLE inventory_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Salon owners can manage their inventory logs"
+  ON inventory_logs FOR ALL
+  USING (
+    salon_id IN (
+      SELECT id FROM salons WHERE owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    salon_id IN (
+      SELECT id FROM salons WHERE owner_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------
+-- 3. purchases テーブル拡張
+--    商品マスタとの紐付け + 原価・売価
+-- ----------------------------------------
+ALTER TABLE purchases ADD COLUMN IF NOT EXISTS product_id UUID REFERENCES products(id) ON DELETE SET NULL;
+ALTER TABLE purchases ADD COLUMN IF NOT EXISTS cost_price INTEGER;
+ALTER TABLE purchases ADD COLUMN IF NOT EXISTS sell_price INTEGER;
+
+-- ----------------------------------------
+-- 4. get_inventory_summary() RPC
+--    全商品の在庫サマリーを取得
+-- ----------------------------------------
+CREATE OR REPLACE FUNCTION get_inventory_summary(p_salon_id uuid)
+RETURNS TABLE (
+  product_id uuid,
+  product_name text,
+  category text,
+  base_sell_price integer,
+  base_cost_price integer,
+  reorder_point integer,
+  is_active boolean,
+  current_stock bigint,
+  stock_value bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    p.id AS product_id,
+    p.name AS product_name,
+    p.category,
+    p.base_sell_price,
+    p.base_cost_price,
+    p.reorder_point,
+    p.is_active,
+    COALESCE(SUM(il.quantity), 0) AS current_stock,
+    COALESCE(SUM(il.quantity), 0) * p.base_cost_price AS stock_value
+  FROM products p
+  LEFT JOIN inventory_logs il ON il.product_id = p.id
+  WHERE p.salon_id = p_salon_id
+    AND p.is_active = true
+  GROUP BY p.id, p.name, p.category, p.base_sell_price, p.base_cost_price, p.reorder_point, p.is_active
+  ORDER BY p.name;
+$$;
+
+-- ----------------------------------------
+-- 5. record_product_sale() RPC
+--    物販登録 + 自動出庫をアトミックに実行
+-- ----------------------------------------
+CREATE OR REPLACE FUNCTION record_product_sale(
+  p_salon_id uuid,
+  p_customer_id uuid,
+  p_product_id uuid,
+  p_quantity integer,
+  p_sell_price integer,
+  p_purchase_date date DEFAULT CURRENT_DATE,
+  p_memo text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_product record;
+  v_purchase_id uuid;
+  v_total_price integer;
+  v_remaining_stock bigint;
+BEGIN
+  -- 商品を取得
+  SELECT * INTO v_product
+  FROM products
+  WHERE id = p_product_id AND salon_id = p_salon_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '商品が見つかりません';
+  END IF;
+
+  v_total_price := p_sell_price * p_quantity;
+
+  -- 物販レコード作成
+  INSERT INTO purchases (
+    salon_id, customer_id, purchase_date, item_name,
+    quantity, unit_price, total_price, memo,
+    product_id, cost_price, sell_price
+  ) VALUES (
+    p_salon_id, p_customer_id, p_purchase_date, v_product.name,
+    p_quantity, p_sell_price, v_total_price, p_memo,
+    p_product_id, v_product.base_cost_price, p_sell_price
+  )
+  RETURNING id INTO v_purchase_id;
+
+  -- 在庫出庫ログ作成（負数）
+  INSERT INTO inventory_logs (
+    salon_id, product_id, log_type, quantity,
+    unit_cost_price, unit_sell_price,
+    related_purchase_id, logged_at
+  ) VALUES (
+    p_salon_id, p_product_id, 'sale_out', -p_quantity,
+    v_product.base_cost_price, p_sell_price,
+    v_purchase_id, p_purchase_date
+  );
+
+  -- 残り在庫を計算
+  SELECT COALESCE(SUM(quantity), 0) INTO v_remaining_stock
+  FROM inventory_logs
+  WHERE product_id = p_product_id;
+
+  RETURN jsonb_build_object(
+    'purchase_id', v_purchase_id,
+    'remaining_stock', v_remaining_stock
+  );
+END;
+$$;
+
+-- ----------------------------------------
+-- 6. get_tax_report() RPC
+--    確定申告用の年間集計データを取得
+-- ----------------------------------------
+CREATE OR REPLACE FUNCTION get_tax_report(
+  p_salon_id uuid,
+  p_year integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_year_start date;
+  v_year_end date;
+  v_prev_year_end date;
+  v_opening_stock_value bigint;
+  v_closing_stock_value bigint;
+  v_total_purchases bigint;
+  v_monthly_purchases jsonb;
+  v_closing_details jsonb;
+BEGIN
+  v_year_start := make_date(p_year, 1, 1);
+  v_year_end := make_date(p_year, 12, 31);
+  v_prev_year_end := make_date(p_year - 1, 12, 31);
+
+  -- 期首棚卸高（前年末までの在庫数 × 基本仕入価）
+  SELECT COALESCE(SUM(sub.stock * sub.base_cost_price), 0)
+  INTO v_opening_stock_value
+  FROM (
+    SELECT
+      il.product_id,
+      p.base_cost_price,
+      SUM(il.quantity) AS stock
+    FROM inventory_logs il
+    JOIN products p ON p.id = il.product_id
+    WHERE il.salon_id = p_salon_id
+      AND il.logged_at <= v_prev_year_end
+    GROUP BY il.product_id, p.base_cost_price
+  ) sub
+  WHERE sub.stock > 0;
+
+  -- 期末棚卸高（当年末までの在庫数 × 基本仕入価）
+  SELECT COALESCE(SUM(sub.stock * sub.base_cost_price), 0)
+  INTO v_closing_stock_value
+  FROM (
+    SELECT
+      il.product_id,
+      p.base_cost_price,
+      SUM(il.quantity) AS stock
+    FROM inventory_logs il
+    JOIN products p ON p.id = il.product_id
+    WHERE il.salon_id = p_salon_id
+      AND il.logged_at <= v_year_end
+    GROUP BY il.product_id, p.base_cost_price
+  ) sub
+  WHERE sub.stock > 0;
+
+  -- 当年仕入合計
+  SELECT COALESCE(SUM(quantity * COALESCE(unit_cost_price, 0)), 0)
+  INTO v_total_purchases
+  FROM inventory_logs
+  WHERE salon_id = p_salon_id
+    AND log_type = 'purchase_in'
+    AND logged_at BETWEEN v_year_start AND v_year_end;
+
+  -- 月別仕入金額
+  SELECT COALESCE(jsonb_agg(row_to_json(sub)), '[]'::jsonb)
+  INTO v_monthly_purchases
+  FROM (
+    SELECT
+      EXTRACT(MONTH FROM logged_at)::integer AS month,
+      SUM(quantity * COALESCE(unit_cost_price, 0)) AS amount
+    FROM inventory_logs
+    WHERE salon_id = p_salon_id
+      AND log_type = 'purchase_in'
+      AND logged_at BETWEEN v_year_start AND v_year_end
+    GROUP BY EXTRACT(MONTH FROM logged_at)
+    ORDER BY month
+  ) sub;
+
+  -- 期末棚卸明細
+  SELECT COALESCE(jsonb_agg(row_to_json(sub)), '[]'::jsonb)
+  INTO v_closing_details
+  FROM (
+    SELECT
+      p.name AS product_name,
+      SUM(il.quantity) AS stock,
+      p.base_cost_price AS unit_price,
+      SUM(il.quantity) * p.base_cost_price AS total_value
+    FROM inventory_logs il
+    JOIN products p ON p.id = il.product_id
+    WHERE il.salon_id = p_salon_id
+      AND il.logged_at <= v_year_end
+    GROUP BY p.id, p.name, p.base_cost_price
+    HAVING SUM(il.quantity) > 0
+    ORDER BY p.name
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'year', p_year,
+    'opening_stock_value', v_opening_stock_value,
+    'closing_stock_value', v_closing_stock_value,
+    'total_purchases', v_total_purchases,
+    'cost_of_goods_sold', v_opening_stock_value + v_total_purchases - v_closing_stock_value,
+    'monthly_purchases', v_monthly_purchases,
+    'closing_stock_details', v_closing_details
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary
- 商品マスタCRUD、在庫ダッシュボード、入出庫記録（仕入/消費/廃棄/返品）、棚卸し機能を実装
- 確定申告レポート（売上原価計算・月別集計・期末棚卸明細）+ CSV出力（汎用/freee/弥生形式）
- 物販フロー強化: 商品選択/自由入力デュアルモード、在庫自動連動（RPCでアトミック処理）
- ナビ「売上」→「経営」改名、売上レポート/在庫管理タブ切替UI
- ダッシュボードに在庫アラート追加（条件付きクエリでパフォーマンス保護）

## Changes
- **New files (9)**: migration, management-tabs, inventory dashboard/loading/products/receive/consume/stocktake/tax-report
- **Modified files (5)**: database.ts, dashboard-header.tsx, sales/page.tsx, purchases/new/page.tsx, dashboard/page.tsx
- **DB**: products + inventory_logs テーブル、3 RPC関数 (get_inventory_summary, record_product_sale, get_tax_report)

## Test plan
- [ ] 商品マスタ: 追加/編集/非表示切替/削除
- [ ] 仕入記録 → 在庫数増加確認
- [ ] 物販記録（商品モード）→ 在庫自動減算確認
- [ ] 消費・廃棄 → 在庫減算確認
- [ ] 棚卸し → 差分調整ログ生成確認
- [ ] 確定申告レポート → 売上原価計算・CSV出力確認
- [ ] ダッシュボード在庫アラート表示確認
- [ ] 商品ゼロユーザーのパフォーマンス影響なし確認
- [ ] `npm run build` ✅ (30ページ、エラー・警告なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)