### PR TITLE
refactor: 予約・顧客詳細ページのコンポーネント分割

### DIFF
--- a/src/app/(dashboard)/appointments/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/appointments/[id]/edit/page.tsx
@@ -6,31 +6,15 @@ import { createClient } from "@/lib/supabase/client";
 import { PageHeader } from "@/components/layout/page-header";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
-import type { Database, BusinessHours } from "@/types/database";
-import {
-  getScheduleForDate,
-  isBusinessDay,
-  isWithinBusinessHours,
-  isIrregularHoliday,
-  timeToMinutes,
-} from "@/lib/business-hours";
+import { TimeSlotVisualization } from "@/components/appointments/time-slot-visualization";
+import { TimePicker } from "@/components/appointments/time-picker";
+import { AppointmentMenuSelector } from "@/components/appointments/appointment-menu-selector";
+import { ClosedDayWarning, getOutsideHoursWarning } from "@/components/appointments/business-hours-warning";
+import { INPUT_CLASS, SOURCE_OPTIONS } from "@/components/appointments/types";
+import type { TreatmentMenu, DayAppointment, BusinessHours } from "@/components/appointments/types";
+import type { Database } from "@/types/database";
 
 type Appointment = Database["public"]["Tables"]["appointments"]["Row"];
-type TreatmentMenu = Database["public"]["Tables"]["treatment_menus"]["Row"];
-type DayAppointment = {
-  id: string;
-  start_time: string;
-  end_time: string | null;
-  customers: { last_name: string; first_name: string } | null;
-};
-
-const SOURCE_OPTIONS = [
-  { value: "direct", label: "直接予約" },
-  { value: "hotpepper", label: "ホットペッパー" },
-  { value: "phone", label: "電話" },
-  { value: "line", label: "LINE" },
-  { value: "other", label: "その他" },
-];
 
 export default function EditAppointmentPage() {
   const router = useRouter();
@@ -64,28 +48,19 @@ export default function EditAppointmentPage() {
 
   const loadData = async () => {
     const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      setLoading(false);
-      return;
-    }
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) { setLoading(false); return; }
 
     const { data: salon } = await supabase
       .from("salons")
       .select("id, business_hours, salon_holidays")
       .eq("owner_id", user.id)
       .single<{ id: string; business_hours: BusinessHours | null; salon_holidays: string[] | null }>();
-    if (!salon) {
-      setLoading(false);
-      return;
-    }
+    if (!salon) { setLoading(false); return; }
     setSalonId(salon.id);
     setBusinessHours(salon.business_hours);
     setSalonHolidays(salon.salon_holidays);
 
-    // P5: salon取得後、appointment + menus + junction を並列取得
     const [appointmentRes, menuRes, junctionRes] = await Promise.all([
       supabase
         .from("appointments")
@@ -108,18 +83,13 @@ export default function EditAppointmentPage() {
     ]);
 
     const appointment = appointmentRes.data;
-    if (!appointment) {
-      router.push("/appointments");
-      return;
-    }
+    if (!appointment) { router.push("/appointments"); return; }
 
     setMenus(menuRes.data ?? []);
 
     const existingMenus = junctionRes.data;
     if (existingMenus && existingMenus.length > 0) {
-      setSelectedMenuIds(
-        existingMenus.map((m) => m.menu_id).filter(Boolean) as string[]
-      );
+      setSelectedMenuIds(existingMenus.map((m) => m.menu_id).filter(Boolean) as string[]);
     } else if (appointment.menu_id) {
       setSelectedMenuIds([appointment.menu_id]);
     }
@@ -144,7 +114,7 @@ export default function EditAppointmentPage() {
     setLoading(false);
   };
 
-  // Fetch day appointments when date changes
+  // 日付変更時に当日の予約を取得
   useEffect(() => {
     if (!salonId || !appointmentDate) return;
     const loadDayAppointments = async () => {
@@ -162,7 +132,7 @@ export default function EditAppointmentPage() {
     loadDayAppointments();
   }, [salonId, appointmentDate]);
 
-  // Auto-calculate end time from selected menus' total duration
+  // メニュー合計時間から終了時間を自動計算
   const updateEndTimeFromMenus = (menuIds: string[], sH: string, sM: string, forceCalc = false) => {
     if (!forceCalc && isEndTimeManual) return;
     const totalDuration = menuIds.reduce((sum, id) => {
@@ -197,7 +167,6 @@ export default function EditAppointmentPage() {
     const startTime = `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}`;
     const endTime = `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`;
 
-    // Validate end > start
     const startMin = Number(startHour) * 60 + Number(startMinute);
     const endMin = Number(endHour) * 60 + Number(endMinute);
     if (endMin <= startMin) {
@@ -206,7 +175,7 @@ export default function EditAppointmentPage() {
       return;
     }
 
-    // Check for overlapping appointments (exclude current)
+    // 重複チェック（自分自身を除外）
     const { data: existing } = await supabase
       .from("appointments")
       .select("id, start_time, end_time, customers(last_name, first_name)")
@@ -220,13 +189,11 @@ export default function EditAppointmentPage() {
         const [hh, mm] = t.slice(0, 5).split(":").map(Number);
         return hh * 60 + mm;
       };
-
       const overlap = existing.find((apt) => {
         const eStart = toMin(apt.start_time);
         const eEnd = apt.end_time ? toMin(apt.end_time) : eStart + 60;
         return startMin < eEnd && eStart < endMin;
       });
-
       if (overlap) {
         const c = overlap.customers as { last_name: string; first_name: string } | null;
         const name = c ? `${c.last_name} ${c.first_name}` : "別の顧客";
@@ -236,7 +203,7 @@ export default function EditAppointmentPage() {
       }
     }
 
-    // Build menu snapshot
+    // メニュースナップショット
     const selectedMenusList = selectedMenuIds.map((id, index) => {
       const menu = menus.find((m) => m.id === id);
       return { id, menu, index };
@@ -246,7 +213,6 @@ export default function EditAppointmentPage() {
       .filter(Boolean)
       .join("、") || null;
 
-    // Update appointment
     const { error: updateError } = await supabase
       .from("appointments")
       .update({
@@ -268,7 +234,7 @@ export default function EditAppointmentPage() {
       return;
     }
 
-    // Update junction table: delete old, insert new
+    // 中間テーブル更新: 旧レコード削除 → 新規挿入
     const { error: deleteError } = await supabase
       .from("appointment_menus")
       .delete()
@@ -290,7 +256,6 @@ export default function EditAppointmentPage() {
         duration_minutes_snapshot: menu?.duration_minutes ?? null,
         sort_order: index,
       }));
-
       const { error: junctionError } = await supabase.from("appointment_menus").insert(junctionRows);
       if (junctionError) {
         console.error("Junction insert error:", junctionError);
@@ -303,7 +268,6 @@ export default function EditAppointmentPage() {
     router.push("/appointments");
   };
 
-  // Calculate total duration and price
   const totalDuration = selectedMenuIds.reduce((sum, id) => {
     const menu = menus.find((m) => m.id === id);
     return sum + (menu?.duration_minutes ?? 0);
@@ -338,303 +302,103 @@ export default function EditAppointmentPage() {
       <form onSubmit={handleSubmit} className="space-y-5">
         {error && <ErrorAlert message={error} />}
 
-        {/* Date */}
+        {/* 予約日 */}
         <div>
-          <label htmlFor="date" className="block text-sm font-medium mb-1.5">
-            予約日
-          </label>
+          <label htmlFor="date" className="block text-sm font-medium mb-1.5">予約日</label>
           <input
             id="date"
             type="date"
             value={appointmentDate}
             onChange={(e) => setAppointmentDate(e.target.value)}
             required
-            className="w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
+            className={INPUT_CLASS}
           />
         </div>
 
-        {/* Closed day warning */}
-        {appointmentDate && businessHours && !isBusinessDay(businessHours, appointmentDate, salonHolidays) && (
-          <div className="bg-warning/10 text-warning text-sm rounded-lg p-3">
-            {isIrregularHoliday(salonHolidays, appointmentDate)
-              ? "この日は臨時休業日に設定されています"
-              : "この日は休業日に設定されています"}
-          </div>
+        {/* 休業日警告 */}
+        {businessHours && (
+          <ClosedDayWarning
+            appointmentDate={appointmentDate}
+            businessHours={businessHours}
+            salonHolidays={salonHolidays}
+          />
         )}
 
-        {/* Time slot visualization */}
-        {appointmentDate && businessHours && (() => {
-          const schedule = getScheduleForDate(businessHours, appointmentDate, salonHolidays);
-          if (!schedule.is_open) return null;
-          const openMin = timeToMinutes(schedule.open_time);
-          const closeMin = timeToMinutes(schedule.close_time);
-          const slotCount = (closeMin - openMin) / 15;
-          if (slotCount <= 0) return null;
-          // Exclude current appointment from occupied slots
-          const otherAppointments = dayAppointments.filter((a) => a.id !== appointmentId);
+        {/* タイムスロット可視化 */}
+        {appointmentDate && businessHours && (
+          <TimeSlotVisualization
+            appointmentDate={appointmentDate}
+            businessHours={businessHours}
+            salonHolidays={salonHolidays}
+            dayAppointments={dayAppointments}
+            excludeAppointmentId={appointmentId}
+            onSlotClick={(h, m) => {
+              setStartHour(String(h));
+              setStartMinute(String(m).padStart(2, "0"));
+              updateEndTimeFromMenus(selectedMenuIds, String(h), String(m).padStart(2, "0"));
+            }}
+          />
+        )}
 
-          return (
-            <div className="space-y-2">
-              <p className="text-xs text-text-light">
-                営業時間: {schedule.open_time} 〜 {schedule.close_time}
-              </p>
-              <div className="overflow-x-auto -mx-1 px-1">
-                {/* Time labels row */}
-                <div className="flex gap-0.5 mb-1" style={{ minWidth: `${slotCount * 20}px` }}>
-                  {Array.from({ length: slotCount }, (_, i) => {
-                    const slotMin = openMin + i * 15;
-                    const isHourMark = slotMin % 60 === 0;
-                    return (
-                      <div key={slotMin} className="flex-shrink-0 text-center" style={{ width: "20px" }}>
-                        {isHourMark && (
-                          <span className="text-[10px] text-text-light">
-                            {Math.floor(slotMin / 60)}:00
-                          </span>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-                {/* Slot buttons row */}
-                <div className="flex gap-0.5" style={{ minWidth: `${slotCount * 20}px` }}>
-                  {Array.from({ length: slotCount }, (_, i) => {
-                    const slotMin = openMin + i * 15;
-                    const slotTime = `${String(Math.floor(slotMin / 60)).padStart(2, "0")}:${String(slotMin % 60).padStart(2, "0")}`;
-                    const isOccupied = otherAppointments.some((apt) => {
-                      const aStart = timeToMinutes(apt.start_time.slice(0, 5));
-                      const aEnd = apt.end_time ? timeToMinutes(apt.end_time.slice(0, 5)) : aStart + 60;
-                      return slotMin >= aStart && slotMin < aEnd;
-                    });
-                    const occupyingApt = isOccupied
-                      ? otherAppointments.find((apt) => {
-                          const aStart = timeToMinutes(apt.start_time.slice(0, 5));
-                          const aEnd = apt.end_time ? timeToMinutes(apt.end_time.slice(0, 5)) : aStart + 60;
-                          return slotMin >= aStart && slotMin < aEnd;
-                        })
-                      : null;
+        {/* 開始時間 */}
+        <TimePicker
+          label="開始時間"
+          hour={startHour}
+          minute={startMinute}
+          onHourChange={(h) => { setStartHour(h); updateEndTimeFromMenus(selectedMenuIds, h, startMinute); }}
+          onMinuteChange={(m) => { setStartMinute(m); updateEndTimeFromMenus(selectedMenuIds, startHour, m); }}
+        />
 
-                    return (
-                      <button
-                        key={slotMin}
-                        type="button"
-                        title={
-                          isOccupied && occupyingApt?.customers
-                            ? `${slotTime} - ${occupyingApt.customers.last_name} ${occupyingApt.customers.first_name}様`
-                            : slotTime
-                        }
-                        onClick={() => {
-                          if (!isOccupied) {
-                            const h = Math.floor(slotMin / 60);
-                            const m = slotMin % 60;
-                            setStartHour(String(h));
-                            setStartMinute(String(m).padStart(2, "0"));
-                            updateEndTimeFromMenus(selectedMenuIds, String(h), String(m).padStart(2, "0"));
-                          }
-                        }}
-                        className={`h-8 flex-shrink-0 rounded-sm transition-colors ${
-                          isOccupied
-                            ? "bg-accent/30 cursor-not-allowed"
-                            : "bg-accent/10 hover:bg-accent/20 cursor-pointer"
-                        }`}
-                        style={{ width: "20px" }}
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-              <div className="flex items-center gap-3 text-[10px] text-text-light">
-                <span className="flex items-center gap-1">
-                  <span className="inline-block w-3 h-3 rounded-sm bg-accent/30" />
-                  予約あり
-                </span>
-                <span className="flex items-center gap-1">
-                  <span className="inline-block w-3 h-3 rounded-sm bg-accent/10" />
-                  空き
-                </span>
-              </div>
-            </div>
-          );
-        })()}
+        {/* 終了時間 */}
+        <TimePicker
+          label="終了予定時間"
+          hour={endHour}
+          minute={endMinute}
+          onHourChange={(h) => { setEndHour(h); setIsEndTimeManual(true); }}
+          onMinuteChange={(m) => { setEndMinute(m); setIsEndTimeManual(true); }}
+          autoCalcInfo={{
+            isManual: isEndTimeManual,
+            hasMenus: selectedMenuIds.length > 0,
+            onResetAuto: () => {
+              setIsEndTimeManual(false);
+              updateEndTimeFromMenus(selectedMenuIds, startHour, startMinute, true);
+            },
+          }}
+          warningMessage={businessHours ? getOutsideHoursWarning({
+            appointmentDate, businessHours, salonHolidays,
+            startHour, startMinute, endHour, endMinute,
+          }) : null}
+        />
 
-        {/* Start time */}
+        {/* メニュー選択 */}
+        <AppointmentMenuSelector
+          menus={menus}
+          selectedMenuIds={selectedMenuIds}
+          onToggle={toggleMenu}
+          totalDuration={totalDuration}
+          totalPrice={totalPrice}
+        />
+
+        {/* 予約経路 */}
         <div>
-          <label className="block text-sm font-medium mb-1.5">開始時間</label>
-          <div className="flex items-center gap-2">
-            <select
-              value={startHour}
-              onChange={(e) => {
-                setStartHour(e.target.value);
-                updateEndTimeFromMenus(selectedMenuIds, e.target.value, startMinute);
-              }}
-              className="flex-1 rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-            >
-              {Array.from({ length: 24 }, (_, i) => (
-                <option key={i} value={String(i)}>{String(i).padStart(2, "0")}</option>
-              ))}
-            </select>
-            <span className="text-lg font-medium">:</span>
-            <select
-              value={startMinute}
-              onChange={(e) => {
-                setStartMinute(e.target.value);
-                updateEndTimeFromMenus(selectedMenuIds, startHour, e.target.value);
-              }}
-              className="flex-1 rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-            >
-              {["00", "15", "30", "45"].map((m) => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        {/* End time */}
-        <div>
-          <div className="flex items-center justify-between mb-1.5">
-            <label className="block text-sm font-medium">終了予定時間</label>
-            {selectedMenuIds.length > 0 && (
-              <span className={`text-xs ${isEndTimeManual ? "text-orange-500" : "text-accent"}`}>
-                {isEndTimeManual ? "手動設定" : "メニューから自動計算"}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            <select
-              value={endHour}
-              onChange={(e) => {
-                setEndHour(e.target.value);
-                setIsEndTimeManual(true);
-              }}
-              className="flex-1 rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-            >
-              {Array.from({ length: 24 }, (_, i) => (
-                <option key={i} value={String(i)}>{String(i).padStart(2, "0")}</option>
-              ))}
-            </select>
-            <span className="text-lg font-medium">:</span>
-            <select
-              value={endMinute}
-              onChange={(e) => {
-                setEndMinute(e.target.value);
-                setIsEndTimeManual(true);
-              }}
-              className="flex-1 rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-            >
-              {["00", "15", "30", "45"].map((m) => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
-          </div>
-          {isEndTimeManual && selectedMenuIds.length > 0 && (
-            <button
-              type="button"
-              onClick={() => {
-                setIsEndTimeManual(false);
-                updateEndTimeFromMenus(selectedMenuIds, startHour, startMinute, true);
-              }}
-              className="text-xs text-accent hover:underline mt-1"
-            >
-              自動計算に戻す
-            </button>
-          )}
-          {businessHours && appointmentDate && isBusinessDay(businessHours, appointmentDate, salonHolidays) &&
-            !isWithinBusinessHours(
-              businessHours,
-              appointmentDate,
-              `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}`,
-              `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`,
-              salonHolidays
-            ) && (() => {
-              const schedule = getScheduleForDate(businessHours, appointmentDate, salonHolidays);
-              const startStr = `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}`;
-              const endStr = `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`;
-              const isBefore = startStr < schedule.open_time;
-              const isAfter = endStr > schedule.close_time;
-              return (
-                <p className="text-xs text-warning mt-1">
-                  {isBefore && isAfter
-                    ? `開始（${startStr}）が営業開始（${schedule.open_time}）より前、終了（${endStr}）が営業終了（${schedule.close_time}）より後です`
-                    : isBefore
-                      ? `開始時間（${startStr}）が営業開始（${schedule.open_time}）より前です`
-                      : `終了時間（${endStr}）が営業終了（${schedule.close_time}）を超えています`
-                  }
-                </p>
-              );
-            })()}
-        </div>
-
-        {/* Menu multi-select */}
-        <div>
-          <label className="block text-sm font-medium mb-1.5">
-            施術メニュー（任意・複数選択可）
-          </label>
-          {menus.length > 0 ? (
-            <div className="bg-surface border border-border rounded-xl p-3 max-h-52 overflow-y-auto space-y-1">
-              {menus.map((m) => (
-                <label
-                  key={m.id}
-                  className="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-background transition-colors cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={selectedMenuIds.includes(m.id)}
-                    onChange={() => toggleMenu(m.id)}
-                    className="w-4 h-4 rounded border-border text-accent focus:ring-accent/50"
-                  />
-                  <span className="text-sm flex-1">{m.name}</span>
-                  <span className="text-xs text-text-light whitespace-nowrap">
-                    {m.duration_minutes ? `${m.duration_minutes}分` : ""}
-                    {m.duration_minutes && m.price ? " / " : ""}
-                    {m.price ? `${m.price.toLocaleString()}円` : ""}
-                  </span>
-                </label>
-              ))}
-            </div>
-          ) : (
-            <div className="bg-surface border border-border rounded-xl p-3 text-sm text-text-light text-center">
-              メニューが登録されていません
-            </div>
-          )}
-          {selectedMenuIds.length > 0 && (
-            <p className="text-xs text-text-light mt-1.5">
-              選択中: {selectedMenuIds.length}件
-              {totalDuration > 0 && ` / 合計 ${totalDuration}分`}
-              {totalPrice > 0 && ` / ${totalPrice.toLocaleString()}円`}
-            </p>
-          )}
-        </div>
-
-        {/* Source */}
-        <div>
-          <label htmlFor="source" className="block text-sm font-medium mb-1.5">
-            予約経路
-          </label>
-          <select
-            id="source"
-            value={source}
-            onChange={(e) => setSource(e.target.value)}
-            className="w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-          >
+          <label htmlFor="source" className="block text-sm font-medium mb-1.5">予約経路</label>
+          <select id="source" value={source} onChange={(e) => setSource(e.target.value)} className={INPUT_CLASS}>
             {SOURCE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>
         </div>
 
-        {/* Memo */}
+        {/* メモ */}
         <div>
-          <label htmlFor="memo" className="block text-sm font-medium mb-1.5">
-            メモ（任意）
-          </label>
+          <label htmlFor="memo" className="block text-sm font-medium mb-1.5">メモ（任意）</label>
           <AutoResizeTextarea
             id="memo"
             value={memo}
             onChange={(e) => setMemo(e.target.value)}
             minRows={2}
             placeholder="施術の要望や注意点など"
-            className="w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
+            className={INPUT_CLASS}
           />
         </div>
 

--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -1,8 +1,12 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { getAuthAndSalon } from "@/lib/supabase/auth-helpers";
-import { formatDateShort } from "@/lib/format";
 import type { Database } from "@/types/database";
+import { VisitAnalytics } from "@/components/customers/visit-analytics";
+import { SalesSummary } from "@/components/customers/sales-summary";
+import { CustomerBasicInfo } from "@/components/customers/customer-basic-info";
+import { PurchaseHistory } from "@/components/customers/purchase-history";
+import { TreatmentHistory } from "@/components/customers/treatment-history";
 import { CourseTicketSection } from "@/components/customers/course-ticket-section";
 
 type Customer = Database["public"]["Tables"]["customers"]["Row"];
@@ -15,17 +19,6 @@ type CourseTicket = Database["public"]["Tables"]["course_tickets"]["Row"];
 type RecordWithMenus = TreatmentRecord & {
   treatment_record_menus: TreatmentRecordMenu[];
 };
-
-function calculateAge(birthDate: string): number {
-  const today = new Date();
-  const birth = new Date(birthDate);
-  let age = today.getFullYear() - birth.getFullYear();
-  const monthDiff = today.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-    age--;
-  }
-  return age;
-}
 
 export default async function CustomerDetailPage({
   params,
@@ -46,7 +39,6 @@ export default async function CustomerDetailPage({
 
   if (!customer) notFound();
 
-  // 全クエリを並列実行（ウォーターフォール解消）
   const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
 
@@ -80,21 +72,20 @@ export default async function CustomerDetailPage({
       .returns<CourseTicket[]>(),
   ]);
 
-  const records = recordsResult.data;
+  const records = recordsResult.data ?? [];
   const nextAppointment = appointmentResult.data;
-  const purchases = purchasesResult.data;
-  const courseTickets = courseTicketsResult.data;
+  const purchases = purchasesResult.data ?? [];
+  const courseTickets = courseTicketsResult.data ?? [];
 
   // 来店分析
-  const visitCount = records?.length ?? 0;
-  const lastVisitDate = records?.[0]?.treatment_date ?? null;
+  const visitCount = records.length;
+  const lastVisitDate = records[0]?.treatment_date ?? null;
   const daysSinceLastVisit = lastVisitDate
     ? Math.floor((Date.now() - new Date(lastVisitDate).getTime()) / (1000 * 60 * 60 * 24))
     : null;
 
-  // 来店間隔の計算
   let avgInterval: number | null = null;
-  if (records && records.length >= 2) {
+  if (records.length >= 2) {
     const dates = records.map((r) => new Date(r.treatment_date).getTime()).sort((a, b) => a - b);
     let totalDays = 0;
     for (let i = 1; i < dates.length; i++) {
@@ -103,28 +94,21 @@ export default async function CustomerDetailPage({
     avgInterval = Math.round(totalDays / (dates.length - 1));
   }
 
-  const purchaseTotal = purchases?.reduce((sum, p) => sum + p.total_price, 0) ?? 0;
+  const purchaseTotal = purchases.reduce((sum, p) => sum + p.total_price, 0);
 
-  // 施術合計: treatment_record_menus から cash/credit のみ集計（実収入）
-  const treatmentTotal = records?.reduce((sum, rec) => {
-    const menus = (rec as RecordWithMenus).treatment_record_menus ?? [];
+  // 施術合計: cash/credit のみ集計
+  const treatmentTotal = records.reduce((sum, rec) => {
+    const menus = rec.treatment_record_menus ?? [];
     return sum + menus
       .filter((m) => m.payment_type === "cash" || m.payment_type === "credit")
       .reduce((mSum, m) => mSum + (m.price_snapshot ?? 0), 0);
-  }, 0) ?? 0;
+  }, 0);
 
-  // 回数券合計
-  const courseTicketTotal = courseTickets?.reduce((sum, t) => sum + (t.price ?? 0), 0) ?? 0;
-
-  // 総合計
-  const grandTotal = treatmentTotal + purchaseTotal + courseTicketTotal;
-
-  // 年齢計算
-  const age = customer.birth_date ? calculateAge(customer.birth_date) : null;
+  const courseTicketTotal = courseTickets.reduce((sum, t) => sum + (t.price ?? 0), 0);
 
   return (
     <div className="space-y-6">
-      {/* Back link */}
+      {/* 戻るリンク */}
       <Link
         href="/customers"
         className="flex items-center gap-1 text-sm text-accent hover:underline"
@@ -135,7 +119,7 @@ export default async function CustomerDetailPage({
         顧客一覧
       </Link>
 
-      {/* Header */}
+      {/* ヘッダー */}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-bold">
@@ -147,309 +131,32 @@ export default async function CustomerDetailPage({
             </p>
           )}
         </div>
-        <Link
-          href={`/customers/${id}/edit`}
-          className="text-sm text-accent hover:underline"
-        >
+        <Link href={`/customers/${id}/edit`} className="text-sm text-accent hover:underline">
           編集
         </Link>
       </div>
 
-      {/* Visit analytics */}
-      <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
-        <h3 className="font-bold text-sm text-text-light">来店分析</h3>
-        <div className="grid grid-cols-3 gap-3 text-center">
-          <div>
-            <p className="text-2xl font-bold text-accent">{visitCount}</p>
-            <p className="text-xs text-text-light">来店回数</p>
-          </div>
-          <div>
-            <p className="text-2xl font-bold">
-              {daysSinceLastVisit !== null ? daysSinceLastVisit : "-"}
-            </p>
-            <p className="text-xs text-text-light">
-              {daysSinceLastVisit !== null ? "日前に来店" : "未来店"}
-            </p>
-          </div>
-          <div>
-            <p className="text-2xl font-bold">
-              {avgInterval !== null ? `${avgInterval}` : "-"}
-            </p>
-            <p className="text-xs text-text-light">
-              {avgInterval !== null ? "日（平均間隔）" : "平均間隔"}
-            </p>
-          </div>
-        </div>
-        {daysSinceLastVisit !== null && daysSinceLastVisit >= 60 && (
-          <div className="bg-orange-50 border border-orange-200 rounded-lg p-3 text-sm text-orange-700">
-            {daysSinceLastVisit >= 90
-              ? "90日以上ご来店がありません。フォローの連絡をおすすめします。"
-              : "60日以上ご来店がありません。"}
-          </div>
-        )}
-        {nextAppointment && (
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-700">
-            次回予約: {formatDateShort(nextAppointment.appointment_date)}{" "}
-            {(nextAppointment.start_time as string).slice(0, 5)}
-            {nextAppointment.menu_name_snapshot && ` / ${nextAppointment.menu_name_snapshot}`}
-          </div>
-        )}
-        {!nextAppointment && visitCount > 0 && (
-          <Link
-            href={`/appointments/new?customer=${id}`}
-            className="block text-center text-sm text-accent hover:underline"
-          >
-            次回予約を登録する
-          </Link>
-        )}
-      </div>
-
-      {/* Sales summary */}
-      {grandTotal > 0 && (
-        <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
-          <h3 className="font-bold text-sm text-text-light">売上サマリー</h3>
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-text-light">施術合計</span>
-              <span>{treatmentTotal.toLocaleString()}円</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-text-light">物販合計</span>
-              <span>{purchaseTotal.toLocaleString()}円</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-text-light">回数券合計</span>
-              <span>{courseTicketTotal.toLocaleString()}円</span>
-            </div>
-            <div className="border-t border-border pt-2 flex justify-between text-sm font-bold">
-              <span>総合計</span>
-              <span className="text-accent">{grandTotal.toLocaleString()}円</span>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Basic info */}
-      <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
-        <h3 className="font-bold text-sm text-text-light">基本情報</h3>
-        {customer.phone ? (
-          <div className="flex">
-            <span className="text-sm text-text-light w-24 shrink-0">電話番号</span>
-            <a href={`tel:${customer.phone}`} className="text-sm text-accent hover:underline">
-              {customer.phone}
-            </a>
-          </div>
-        ) : (
-          <InfoRowEmpty label="電話番号" editHref={`/customers/${id}/edit`} />
-        )}
-        {customer.email ? (
-          <div className="flex">
-            <span className="text-sm text-text-light w-24 shrink-0">メール</span>
-            <a href={`mailto:${customer.email}`} className="text-sm text-accent hover:underline break-all">
-              {customer.email}
-            </a>
-          </div>
-        ) : (
-          <InfoRowEmpty label="メール" editHref={`/customers/${id}/edit`} />
-        )}
-        {customer.birth_date ? (
-          <InfoRow
-            label="生年月日"
-            value={
-              age !== null
-                ? `${customer.birth_date}（${age}歳）`
-                : customer.birth_date
-            }
-          />
-        ) : (
-          <InfoRowEmpty label="生年月日" editHref={`/customers/${id}/edit`} />
-        )}
-        <InfoRow label="住所" value={customer.address} />
-        <InfoRow label="婚姻状況" value={customer.marital_status} />
-        <InfoRow
-          label="お子様"
-          value={
-            customer.has_children === null
-              ? null
-              : customer.has_children
-                ? "あり"
-                : "なし"
-          }
-        />
-        <InfoRow
-          label="DM送付"
-          value={
-            customer.dm_allowed === null
-              ? null
-              : customer.dm_allowed
-                ? "可"
-                : "不可"
-          }
-        />
-      </div>
-
-      {/* Treatment related info */}
-      <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
-        <h3 className="font-bold text-sm text-text-light">施術関連情報</h3>
-        <InfoRow
-          label="身長"
-          value={customer.height_cm !== null ? `${customer.height_cm} cm` : null}
-        />
-        <InfoRow
-          label="体重"
-          value={customer.weight_kg !== null ? `${customer.weight_kg} kg` : null}
-        />
-        <InfoRow label="アレルギー" value={customer.allergies} />
-        <InfoRow label="最終目標" value={customer.treatment_goal} />
-        <InfoRow label="メモ" value={customer.notes} />
-      </div>
-
-      {/* Course tickets */}
-      <CourseTicketSection
+      <VisitAnalytics
         customerId={id}
-        initialTickets={courseTickets ?? []}
+        visitCount={visitCount}
+        daysSinceLastVisit={daysSinceLastVisit}
+        avgInterval={avgInterval}
+        nextAppointment={nextAppointment}
       />
 
-      {/* Purchase history */}
-      <div>
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="font-bold">
-            物販購入履歴
-            {purchaseTotal > 0 && (
-              <span className="text-sm font-normal text-text-light ml-2">
-                合計 {purchaseTotal.toLocaleString()}円
-              </span>
-            )}
-          </h3>
-          <Link
-            href={`/customers/${id}/purchases/new`}
-            className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[40px] flex items-center"
-          >
-            + 購入記録
-          </Link>
-        </div>
+      <SalesSummary
+        treatmentTotal={treatmentTotal}
+        purchaseTotal={purchaseTotal}
+        courseTicketTotal={courseTicketTotal}
+      />
 
-        {purchases && purchases.length > 0 ? (
-          <div className="space-y-2">
-            {purchases.map((purchase) => (
-              <div
-                key={purchase.id}
-                className="bg-surface border border-border rounded-xl p-3"
-              >
-                <div className="flex justify-between items-center">
-                  <span className="font-medium text-sm">
-                    {purchase.item_name}
-                  </span>
-                  <span className="text-sm text-text-light">
-                    {formatDateShort(purchase.purchase_date)}
-                  </span>
-                </div>
-                <div className="flex justify-between items-center mt-1">
-                  <span className="text-xs text-text-light">
-                    {purchase.unit_price.toLocaleString()}円 x{" "}
-                    {purchase.quantity}
-                  </span>
-                  <span className="text-sm font-medium">
-                    {purchase.total_price.toLocaleString()}円
-                  </span>
-                </div>
-                {purchase.memo && (
-                  <p className="text-xs text-text-light mt-1">
-                    {purchase.memo}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="bg-surface border border-border rounded-xl p-6 text-center">
-            <p className="text-text-light text-sm">購入記録はまだありません</p>
-            <Link
-              href={`/customers/${id}/purchases/new`}
-              className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
-            >
-              最初の購入を記録する →
-            </Link>
-          </div>
-        )}
-      </div>
+      <CustomerBasicInfo customer={customer} customerId={id} />
 
-      {/* Treatment records */}
-      <div>
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="font-bold">施術履歴</h3>
-          <Link
-            href={`/records/new?customer=${id}`}
-            className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[40px] flex items-center"
-          >
-            + カルテ作成
-          </Link>
-        </div>
+      <CourseTicketSection customerId={id} initialTickets={courseTickets} />
 
-        {records && records.length > 0 ? (
-          <div className="space-y-2">
-            {records.map((record) => {
-              // treatment_record_menus があればそちらを優先、なければ旧 menu_name_snapshot
-              const recordMenus = (record as RecordWithMenus).treatment_record_menus ?? [];
-              const menuDisplay = recordMenus.length > 0
-                ? recordMenus.map((rm) => rm.menu_name_snapshot).join("、")
-                : record.menu_name_snapshot ?? "施術記録";
-              return (
-                <Link
-                  key={record.id}
-                  href={`/records/${record.id}`}
-                  className="block bg-surface border border-border rounded-xl p-3 hover:border-accent transition-colors"
-                >
-                  <div className="flex justify-between items-center">
-                    <span className="font-medium text-sm truncate mr-2">
-                      {menuDisplay}
-                    </span>
-                    <span className="text-sm text-text-light shrink-0">
-                      {formatDateShort(record.treatment_date)}
-                    </span>
-                  </div>
-                  {record.next_visit_memo && (
-                    <p className="text-sm text-text-light mt-1 truncate">
-                      次回: {record.next_visit_memo}
-                    </p>
-                  )}
-                </Link>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="bg-surface border border-border rounded-xl p-6 text-center">
-            <p className="text-text-light text-sm">施術記録はまだありません</p>
-            <Link
-              href={`/records/new?customer=${id}`}
-              className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
-            >
-              最初のカルテを作成する →
-            </Link>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+      <PurchaseHistory customerId={id} purchases={purchases} purchaseTotal={purchaseTotal} />
 
-function InfoRow({ label, value }: { label: string; value: string | null }) {
-  if (!value) return null;
-  return (
-    <div className="flex">
-      <span className="text-sm text-text-light w-24 shrink-0">{label}</span>
-      <span className="text-sm">{value}</span>
-    </div>
-  );
-}
-
-function InfoRowEmpty({ label, editHref }: { label: string; editHref: string }) {
-  return (
-    <div className="flex">
-      <span className="text-sm text-text-light w-24 shrink-0">{label}</span>
-      <Link href={editHref} className="text-sm text-gray-400 hover:text-accent transition-colors">
-        未登録 →
-      </Link>
+      <TreatmentHistory customerId={id} records={records} />
     </div>
   );
 }

--- a/src/components/appointments/appointment-menu-selector.tsx
+++ b/src/components/appointments/appointment-menu-selector.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { TreatmentMenu } from "./types";
+
+type Props = {
+  menus: TreatmentMenu[];
+  selectedMenuIds: string[];
+  onToggle: (menuId: string) => void;
+  totalDuration: number;
+  totalPrice: number;
+};
+
+export function AppointmentMenuSelector({
+  menus,
+  selectedMenuIds,
+  onToggle,
+  totalDuration,
+  totalPrice,
+}: Props) {
+  return (
+    <div>
+      <label className="block text-sm font-medium mb-1.5">
+        施術メニュー（任意・複数選択可）
+      </label>
+      {menus.length > 0 ? (
+        <div className="bg-surface border border-border rounded-xl p-3 max-h-52 overflow-y-auto space-y-1">
+          {menus.map((m) => (
+            <label
+              key={m.id}
+              className="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-background transition-colors cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={selectedMenuIds.includes(m.id)}
+                onChange={() => onToggle(m.id)}
+                className="w-4 h-4 rounded border-border text-accent focus:ring-accent/50"
+              />
+              <span className="text-sm flex-1">{m.name}</span>
+              <span className="text-xs text-text-light whitespace-nowrap">
+                {m.duration_minutes ? `${m.duration_minutes}分` : ""}
+                {m.duration_minutes && m.price ? " / " : ""}
+                {m.price ? `${m.price.toLocaleString()}円` : ""}
+              </span>
+            </label>
+          ))}
+        </div>
+      ) : (
+        <div className="bg-surface border border-border rounded-xl p-3 text-sm text-text-light text-center">
+          メニューが登録されていません
+        </div>
+      )}
+      {selectedMenuIds.length > 0 && (
+        <p className="text-xs text-text-light mt-1.5">
+          選択中: {selectedMenuIds.length}件
+          {totalDuration > 0 && ` / 合計 ${totalDuration}分`}
+          {totalPrice > 0 && ` / ${totalPrice.toLocaleString()}円`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/appointments/business-hours-warning.tsx
+++ b/src/components/appointments/business-hours-warning.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  isBusinessDay,
+  isIrregularHoliday,
+  getScheduleForDate,
+  isWithinBusinessHours,
+} from "@/lib/business-hours";
+import type { BusinessHours } from "./types";
+
+type ClosedDayProps = {
+  appointmentDate: string;
+  businessHours: BusinessHours;
+  salonHolidays: string[] | null;
+};
+
+/** 休業日警告 */
+export function ClosedDayWarning({ appointmentDate, businessHours, salonHolidays }: ClosedDayProps) {
+  if (!appointmentDate || !businessHours) return null;
+  if (isBusinessDay(businessHours, appointmentDate, salonHolidays)) return null;
+
+  return (
+    <div className="bg-warning/10 text-warning text-sm rounded-lg p-3">
+      {isIrregularHoliday(salonHolidays, appointmentDate)
+        ? "この日は臨時休業日に設定されています"
+        : "この日は休業日に設定されています"}
+    </div>
+  );
+}
+
+type OutsideHoursProps = {
+  appointmentDate: string;
+  businessHours: BusinessHours;
+  salonHolidays: string[] | null;
+  startHour: string;
+  startMinute: string;
+  endHour: string;
+  endMinute: string;
+};
+
+/** 営業時間外の警告メッセージを返す（営業時間内ならnull） */
+export function getOutsideHoursWarning({
+  appointmentDate,
+  businessHours,
+  salonHolidays,
+  startHour,
+  startMinute,
+  endHour,
+  endMinute,
+}: OutsideHoursProps): string | null {
+  if (!businessHours || !appointmentDate) return null;
+  if (!isBusinessDay(businessHours, appointmentDate, salonHolidays)) return null;
+
+  const startStr = `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}`;
+  const endStr = `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`;
+
+  if (isWithinBusinessHours(businessHours, appointmentDate, startStr, endStr, salonHolidays)) {
+    return null;
+  }
+
+  const schedule = getScheduleForDate(businessHours, appointmentDate, salonHolidays);
+  const isBefore = startStr < schedule.open_time;
+  const isAfter = endStr > schedule.close_time;
+
+  if (isBefore && isAfter) {
+    return `開始（${startStr}）が営業開始（${schedule.open_time}）より前、終了（${endStr}）が営業終了（${schedule.close_time}）より後です`;
+  }
+  if (isBefore) {
+    return `開始時間（${startStr}）が営業開始（${schedule.open_time}）より前です`;
+  }
+  return `終了時間（${endStr}）が営業終了（${schedule.close_time}）を超えています`;
+}

--- a/src/components/appointments/time-picker.tsx
+++ b/src/components/appointments/time-picker.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { SELECT_CLASS } from "./types";
+
+type Props = {
+  label: string;
+  hour: string;
+  minute: string;
+  onHourChange: (h: string) => void;
+  onMinuteChange: (m: string) => void;
+  /** 自動計算の表示制御 */
+  autoCalcInfo?: {
+    isManual: boolean;
+    hasMenus: boolean;
+    onResetAuto: () => void;
+  };
+  /** 営業時間外警告メッセージ */
+  warningMessage?: string | null;
+};
+
+export function TimePicker({
+  label,
+  hour,
+  minute,
+  onHourChange,
+  onMinuteChange,
+  autoCalcInfo,
+  warningMessage,
+}: Props) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1.5">
+        <label className="block text-sm font-medium">{label}</label>
+        {autoCalcInfo && autoCalcInfo.hasMenus && (
+          <span className={`text-xs ${autoCalcInfo.isManual ? "text-orange-500" : "text-accent"}`}>
+            {autoCalcInfo.isManual ? "手動設定" : "メニューから自動計算"}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <select
+          value={hour}
+          onChange={(e) => onHourChange(e.target.value)}
+          className={SELECT_CLASS}
+        >
+          {Array.from({ length: 24 }, (_, i) => (
+            <option key={i} value={String(i)}>{String(i).padStart(2, "0")}</option>
+          ))}
+        </select>
+        <span className="text-lg font-medium">:</span>
+        <select
+          value={minute}
+          onChange={(e) => onMinuteChange(e.target.value)}
+          className={SELECT_CLASS}
+        >
+          {["00", "15", "30", "45"].map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+      </div>
+      {autoCalcInfo && autoCalcInfo.isManual && autoCalcInfo.hasMenus && (
+        <button
+          type="button"
+          onClick={autoCalcInfo.onResetAuto}
+          className="text-xs text-accent hover:underline mt-1"
+        >
+          自動計算に戻す
+        </button>
+      )}
+      {warningMessage && (
+        <p className="text-xs text-warning mt-1">{warningMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/appointments/time-slot-visualization.tsx
+++ b/src/components/appointments/time-slot-visualization.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import {
+  getScheduleForDate,
+  timeToMinutes,
+} from "@/lib/business-hours";
+import type { BusinessHours, DayAppointment } from "./types";
+
+type Props = {
+  appointmentDate: string;
+  businessHours: BusinessHours;
+  salonHolidays: string[] | null;
+  dayAppointments: DayAppointment[];
+  /** 編集ページの場合、現在の予約を除外するためのID */
+  excludeAppointmentId?: string;
+  onSlotClick: (hour: number, minute: number) => void;
+};
+
+export function TimeSlotVisualization({
+  appointmentDate,
+  businessHours,
+  salonHolidays,
+  dayAppointments,
+  excludeAppointmentId,
+  onSlotClick,
+}: Props) {
+  const schedule = getScheduleForDate(businessHours, appointmentDate, salonHolidays);
+  if (!schedule.is_open) return null;
+
+  const openMin = timeToMinutes(schedule.open_time);
+  const closeMin = timeToMinutes(schedule.close_time);
+  const slotCount = (closeMin - openMin) / 15;
+  if (slotCount <= 0) return null;
+
+  const appointments = excludeAppointmentId
+    ? dayAppointments.filter((a) => a.id !== excludeAppointmentId)
+    : dayAppointments;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-text-light">
+        営業時間: {schedule.open_time} 〜 {schedule.close_time}
+      </p>
+      <div className="overflow-x-auto -mx-1 px-1">
+        {/* 時刻ラベル行 */}
+        <div className="flex gap-0.5 mb-1" style={{ minWidth: `${slotCount * 20}px` }}>
+          {Array.from({ length: slotCount }, (_, i) => {
+            const slotMin = openMin + i * 15;
+            const isHourMark = slotMin % 60 === 0;
+            return (
+              <div key={slotMin} className="flex-shrink-0 text-center" style={{ width: "20px" }}>
+                {isHourMark && (
+                  <span className="text-[10px] text-text-light">
+                    {Math.floor(slotMin / 60)}:00
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {/* スロットボタン行 */}
+        <div className="flex gap-0.5" style={{ minWidth: `${slotCount * 20}px` }}>
+          {Array.from({ length: slotCount }, (_, i) => {
+            const slotMin = openMin + i * 15;
+            const slotTime = `${String(Math.floor(slotMin / 60)).padStart(2, "0")}:${String(slotMin % 60).padStart(2, "0")}`;
+            const isOccupied = appointments.some((apt) => {
+              const aStart = timeToMinutes(apt.start_time.slice(0, 5));
+              const aEnd = apt.end_time ? timeToMinutes(apt.end_time.slice(0, 5)) : aStart + 60;
+              return slotMin >= aStart && slotMin < aEnd;
+            });
+            const occupyingApt = isOccupied
+              ? appointments.find((apt) => {
+                  const aStart = timeToMinutes(apt.start_time.slice(0, 5));
+                  const aEnd = apt.end_time ? timeToMinutes(apt.end_time.slice(0, 5)) : aStart + 60;
+                  return slotMin >= aStart && slotMin < aEnd;
+                })
+              : null;
+
+            return (
+              <button
+                key={slotMin}
+                type="button"
+                title={
+                  isOccupied && occupyingApt?.customers
+                    ? `${slotTime} - ${occupyingApt.customers.last_name} ${occupyingApt.customers.first_name}様`
+                    : slotTime
+                }
+                onClick={() => {
+                  if (!isOccupied) {
+                    onSlotClick(Math.floor(slotMin / 60), slotMin % 60);
+                  }
+                }}
+                className={`h-8 flex-shrink-0 rounded-sm transition-colors ${
+                  isOccupied
+                    ? "bg-accent/30 cursor-not-allowed"
+                    : "bg-accent/10 hover:bg-accent/20 cursor-pointer"
+                }`}
+                style={{ width: "20px" }}
+              />
+            );
+          })}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 text-[10px] text-text-light">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm bg-accent/30" />
+          予約あり
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm bg-accent/10" />
+          空き
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/appointments/types.ts
+++ b/src/components/appointments/types.ts
@@ -1,0 +1,26 @@
+import type { Database, BusinessHours } from "@/types/database";
+
+export type TreatmentMenu = Database["public"]["Tables"]["treatment_menus"]["Row"];
+
+export type DayAppointment = {
+  id: string;
+  start_time: string;
+  end_time: string | null;
+  customers: { last_name: string; first_name: string } | null;
+};
+
+export const SOURCE_OPTIONS = [
+  { value: "direct", label: "直接予約" },
+  { value: "hotpepper", label: "ホットペッパー" },
+  { value: "phone", label: "電話" },
+  { value: "line", label: "LINE" },
+  { value: "other", label: "その他" },
+];
+
+export const INPUT_CLASS =
+  "w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors";
+
+export const SELECT_CLASS =
+  "flex-1 rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors";
+
+export type { BusinessHours };

--- a/src/components/customers/customer-basic-info.tsx
+++ b/src/components/customers/customer-basic-info.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import type { Database } from "@/types/database";
+
+type Customer = Database["public"]["Tables"]["customers"]["Row"];
+
+type Props = {
+  customer: Customer;
+  customerId: string;
+};
+
+function InfoRow({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+  return (
+    <div className="flex">
+      <span className="text-sm text-text-light w-24 shrink-0">{label}</span>
+      <span className="text-sm">{value}</span>
+    </div>
+  );
+}
+
+function InfoRowEmpty({ label, editHref }: { label: string; editHref: string }) {
+  return (
+    <div className="flex">
+      <span className="text-sm text-text-light w-24 shrink-0">{label}</span>
+      <Link href={editHref} className="text-sm text-gray-400 hover:text-accent transition-colors">
+        未登録 →
+      </Link>
+    </div>
+  );
+}
+
+function calculateAge(birthDate: string): number {
+  const today = new Date();
+  const birth = new Date(birthDate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export function CustomerBasicInfo({ customer, customerId }: Props) {
+  const editHref = `/customers/${customerId}/edit`;
+  const age = customer.birth_date ? calculateAge(customer.birth_date) : null;
+
+  return (
+    <>
+      <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+        <h3 className="font-bold text-sm text-text-light">基本情報</h3>
+        {customer.phone ? (
+          <div className="flex">
+            <span className="text-sm text-text-light w-24 shrink-0">電話番号</span>
+            <a href={`tel:${customer.phone}`} className="text-sm text-accent hover:underline">
+              {customer.phone}
+            </a>
+          </div>
+        ) : (
+          <InfoRowEmpty label="電話番号" editHref={editHref} />
+        )}
+        {customer.email ? (
+          <div className="flex">
+            <span className="text-sm text-text-light w-24 shrink-0">メール</span>
+            <a href={`mailto:${customer.email}`} className="text-sm text-accent hover:underline break-all">
+              {customer.email}
+            </a>
+          </div>
+        ) : (
+          <InfoRowEmpty label="メール" editHref={editHref} />
+        )}
+        {customer.birth_date ? (
+          <InfoRow
+            label="生年月日"
+            value={age !== null ? `${customer.birth_date}（${age}歳）` : customer.birth_date}
+          />
+        ) : (
+          <InfoRowEmpty label="生年月日" editHref={editHref} />
+        )}
+        <InfoRow label="住所" value={customer.address} />
+        <InfoRow label="婚姻状況" value={customer.marital_status} />
+        <InfoRow
+          label="お子様"
+          value={customer.has_children === null ? null : customer.has_children ? "あり" : "なし"}
+        />
+        <InfoRow
+          label="DM送付"
+          value={customer.dm_allowed === null ? null : customer.dm_allowed ? "可" : "不可"}
+        />
+      </div>
+
+      <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+        <h3 className="font-bold text-sm text-text-light">施術関連情報</h3>
+        <InfoRow label="身長" value={customer.height_cm !== null ? `${customer.height_cm} cm` : null} />
+        <InfoRow label="体重" value={customer.weight_kg !== null ? `${customer.weight_kg} kg` : null} />
+        <InfoRow label="アレルギー" value={customer.allergies} />
+        <InfoRow label="最終目標" value={customer.treatment_goal} />
+        <InfoRow label="メモ" value={customer.notes} />
+      </div>
+    </>
+  );
+}

--- a/src/components/customers/purchase-history.tsx
+++ b/src/components/customers/purchase-history.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { formatDateShort } from "@/lib/format";
+import type { Database } from "@/types/database";
+
+type Purchase = Database["public"]["Tables"]["purchases"]["Row"];
+
+type Props = {
+  customerId: string;
+  purchases: Purchase[];
+  purchaseTotal: number;
+};
+
+export function PurchaseHistory({ customerId, purchases, purchaseTotal }: Props) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-bold">
+          物販購入履歴
+          {purchaseTotal > 0 && (
+            <span className="text-sm font-normal text-text-light ml-2">
+              合計 {purchaseTotal.toLocaleString()}円
+            </span>
+          )}
+        </h3>
+        <Link
+          href={`/customers/${customerId}/purchases/new`}
+          className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[40px] flex items-center"
+        >
+          + 購入記録
+        </Link>
+      </div>
+
+      {purchases.length > 0 ? (
+        <div className="space-y-2">
+          {purchases.map((purchase) => (
+            <div key={purchase.id} className="bg-surface border border-border rounded-xl p-3">
+              <div className="flex justify-between items-center">
+                <span className="font-medium text-sm">{purchase.item_name}</span>
+                <span className="text-sm text-text-light">{formatDateShort(purchase.purchase_date)}</span>
+              </div>
+              <div className="flex justify-between items-center mt-1">
+                <span className="text-xs text-text-light">
+                  {purchase.unit_price.toLocaleString()}円 x {purchase.quantity}
+                </span>
+                <span className="text-sm font-medium">{purchase.total_price.toLocaleString()}円</span>
+              </div>
+              {purchase.memo && (
+                <p className="text-xs text-text-light mt-1">{purchase.memo}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="bg-surface border border-border rounded-xl p-6 text-center">
+          <p className="text-text-light text-sm">購入記録はまだありません</p>
+          <Link
+            href={`/customers/${customerId}/purchases/new`}
+            className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
+          >
+            最初の購入を記録する →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/customers/sales-summary.tsx
+++ b/src/components/customers/sales-summary.tsx
@@ -1,0 +1,34 @@
+type Props = {
+  treatmentTotal: number;
+  purchaseTotal: number;
+  courseTicketTotal: number;
+};
+
+export function SalesSummary({ treatmentTotal, purchaseTotal, courseTicketTotal }: Props) {
+  const grandTotal = treatmentTotal + purchaseTotal + courseTicketTotal;
+  if (grandTotal <= 0) return null;
+
+  return (
+    <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+      <h3 className="font-bold text-sm text-text-light">売上サマリー</h3>
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-text-light">施術合計</span>
+          <span>{treatmentTotal.toLocaleString()}円</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-text-light">物販合計</span>
+          <span>{purchaseTotal.toLocaleString()}円</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-text-light">回数券合計</span>
+          <span>{courseTicketTotal.toLocaleString()}円</span>
+        </div>
+        <div className="border-t border-border pt-2 flex justify-between text-sm font-bold">
+          <span>総合計</span>
+          <span className="text-accent">{grandTotal.toLocaleString()}円</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customers/treatment-history.tsx
+++ b/src/components/customers/treatment-history.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { formatDateShort } from "@/lib/format";
+import type { Database } from "@/types/database";
+
+type TreatmentRecord = Database["public"]["Tables"]["treatment_records"]["Row"];
+type TreatmentRecordMenu = Database["public"]["Tables"]["treatment_record_menus"]["Row"];
+
+type RecordWithMenus = TreatmentRecord & {
+  treatment_record_menus: TreatmentRecordMenu[];
+};
+
+type Props = {
+  customerId: string;
+  records: RecordWithMenus[];
+};
+
+export function TreatmentHistory({ customerId, records }: Props) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-bold">施術履歴</h3>
+        <Link
+          href={`/records/new?customer=${customerId}`}
+          className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[40px] flex items-center"
+        >
+          + カルテ作成
+        </Link>
+      </div>
+
+      {records.length > 0 ? (
+        <div className="space-y-2">
+          {records.map((record) => {
+            const recordMenus = record.treatment_record_menus ?? [];
+            const menuDisplay = recordMenus.length > 0
+              ? recordMenus.map((rm) => rm.menu_name_snapshot).join("、")
+              : record.menu_name_snapshot ?? "施術記録";
+            return (
+              <Link
+                key={record.id}
+                href={`/records/${record.id}`}
+                className="block bg-surface border border-border rounded-xl p-3 hover:border-accent transition-colors"
+              >
+                <div className="flex justify-between items-center">
+                  <span className="font-medium text-sm truncate mr-2">{menuDisplay}</span>
+                  <span className="text-sm text-text-light shrink-0">{formatDateShort(record.treatment_date)}</span>
+                </div>
+                {record.next_visit_memo && (
+                  <p className="text-sm text-text-light mt-1 truncate">次回: {record.next_visit_memo}</p>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="bg-surface border border-border rounded-xl p-6 text-center">
+          <p className="text-text-light text-sm">施術記録はまだありません</p>
+          <Link
+            href={`/records/new?customer=${customerId}`}
+            className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
+          >
+            最初のカルテを作成する →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/customers/visit-analytics.tsx
+++ b/src/components/customers/visit-analytics.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { formatDateShort } from "@/lib/format";
+import type { Database } from "@/types/database";
+
+type Appointment = Database["public"]["Tables"]["appointments"]["Row"];
+
+type Props = {
+  customerId: string;
+  visitCount: number;
+  daysSinceLastVisit: number | null;
+  avgInterval: number | null;
+  nextAppointment: Appointment | null;
+};
+
+export function VisitAnalytics({
+  customerId,
+  visitCount,
+  daysSinceLastVisit,
+  avgInterval,
+  nextAppointment,
+}: Props) {
+  return (
+    <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+      <h3 className="font-bold text-sm text-text-light">来店分析</h3>
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <div>
+          <p className="text-2xl font-bold text-accent">{visitCount}</p>
+          <p className="text-xs text-text-light">来店回数</p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold">
+            {daysSinceLastVisit !== null ? daysSinceLastVisit : "-"}
+          </p>
+          <p className="text-xs text-text-light">
+            {daysSinceLastVisit !== null ? "日前に来店" : "未来店"}
+          </p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold">
+            {avgInterval !== null ? `${avgInterval}` : "-"}
+          </p>
+          <p className="text-xs text-text-light">
+            {avgInterval !== null ? "日（平均間隔）" : "平均間隔"}
+          </p>
+        </div>
+      </div>
+      {daysSinceLastVisit !== null && daysSinceLastVisit >= 60 && (
+        <div className="bg-orange-50 border border-orange-200 rounded-lg p-3 text-sm text-orange-700">
+          {daysSinceLastVisit >= 90
+            ? "90日以上ご来店がありません。フォローの連絡をおすすめします。"
+            : "60日以上ご来店がありません。"}
+        </div>
+      )}
+      {nextAppointment && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-700">
+          次回予約: {formatDateShort(nextAppointment.appointment_date)}{" "}
+          {(nextAppointment.start_time as string).slice(0, 5)}
+          {nextAppointment.menu_name_snapshot && ` / ${nextAppointment.menu_name_snapshot}`}
+        </div>
+      )}
+      {!nextAppointment && visitCount > 0 && (
+        <Link
+          href={`/appointments/new?customer=${customerId}`}
+          className="block text-center text-sm text-accent hover:underline"
+        >
+          次回予約を登録する
+        </Link>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 予約の新規作成・編集ページから共通UIコンポーネント5つを抽出（タイムスロット、時間ピッカー、メニュー選択、営業時間警告、型定義）
- 顧客詳細ページを5つの独立コンポーネントに分割（来店分析、売上サマリー、基本情報、物販履歴、施術履歴）
- 合計で約990行削減、各ページ300行以内に収まりメンテナビリティ向上

## Test plan
- [ ] 予約新規作成: 顧客選択 → メニュー選択 → 日時設定 → タイムスロット表示 → 保存
- [ ] 予約編集: 既存データの表示 → 時間変更 → メニュー変更 → 更新
- [ ] 営業時間警告: 休業日・営業時間外の警告表示
- [ ] 顧客詳細: 来店分析 → 売上サマリー → 基本情報 → 回数券 → 物販履歴 → 施術履歴
- [ ] ビルド成功（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)