### PR TITLE
feat: データ取り込みハブ + 商品・施術履歴CSVインポート

### DIFF
--- a/src/app/(dashboard)/settings/import-customers/page.tsx
+++ b/src/app/(dashboard)/settings/import-customers/page.tsx
@@ -198,10 +198,11 @@ export default function ImportCustomersPage() {
     <div className="space-y-4">
       <PageHeader
         title="顧客データ取り込み"
-        backLabel="設定"
-        backHref="/settings"
+        backLabel="データ取り込み"
+        backHref="/settings/import"
         breadcrumbs={[
           { label: "設定", href: "/settings" },
+          { label: "データ取り込み", href: "/settings/import" },
           { label: "顧客データ取り込み" },
         ]}
       />
@@ -448,10 +449,10 @@ export default function ImportCustomersPage() {
             </div>
           )}
 
-          <div className="flex gap-3 pt-2">
+          <div className="space-y-2 pt-2">
             <Link
               href="/customers"
-              className="flex-1 bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors min-h-[48px] text-center"
+              className="block w-full bg-accent hover:bg-accent-light text-white font-medium rounded-xl py-3 transition-colors min-h-[48px] text-center"
             >
               顧客一覧を見る
             </Link>
@@ -467,10 +468,16 @@ export default function ImportCustomersPage() {
                 // 既存顧客リストを更新
                 loadSalonData();
               }}
-              className="flex-1 bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
+              className="block w-full bg-background border border-border text-text font-medium rounded-xl py-3 transition-colors min-h-[48px]"
             >
               続けて取り込む
             </button>
+            <Link
+              href="/settings/import"
+              className="block w-full text-sm text-accent text-center py-2 hover:underline"
+            >
+              データ取り込みに戻る
+            </Link>
           </div>
         </div>
       )}

--- a/src/app/(dashboard)/settings/import-products/loading.tsx
+++ b/src/app/(dashboard)/settings/import-products/loading.tsx
@@ -1,0 +1,16 @@
+export default function ImportProductsLoading() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="h-8 bg-border rounded w-1/3" />
+      <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+        <div className="h-4 bg-border rounded w-1/2" />
+        <div className="h-3 bg-border rounded w-2/3" />
+        <div className="h-10 bg-border rounded w-1/3" />
+      </div>
+      <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+        <div className="h-4 bg-border rounded w-1/2" />
+        <div className="h-24 bg-border rounded" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/import-products/page.tsx
+++ b/src/app/(dashboard)/settings/import-products/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { CsvUploadStep } from "@/components/import/csv-upload-step";
+import { CsvPreviewTable, type ColumnDef } from "@/components/import/csv-preview-table";
+import { CsvImportingStep } from "@/components/import/csv-importing-step";
+import { CsvResultStep } from "@/components/import/csv-result-step";
+import { parseCSV } from "@/lib/csv-parse";
+import { validateProductRows, type ProductRowValidation } from "@/lib/csv-import-products";
+
+type Step = "upload" | "preview" | "importing" | "result";
+
+const TEMPLATE_HEADER = "商品名,カテゴリ,販売価格,仕入価格,発注点,メモ";
+const TEMPLATE_SAMPLE = "シャンプーA,ヘアケア,2500,1200,3,人気商品";
+
+const columns: ColumnDef[] = [
+  { key: "name", label: "商品名", render: (r: ProductRowValidation) => r.data.name },
+  { key: "category", label: "カテゴリ", render: (r: ProductRowValidation) => r.data.category ?? "-" },
+  { key: "sell", label: "売価", render: (r: ProductRowValidation) => r.data.base_sell_price ? `¥${r.data.base_sell_price.toLocaleString()}` : "-" },
+  { key: "cost", label: "仕入", render: (r: ProductRowValidation) => r.data.base_cost_price ? `¥${r.data.base_cost_price.toLocaleString()}` : "-" },
+];
+
+export default function ImportProductsPage() {
+  const [step, setStep] = useState<Step>("upload");
+  const [error, setError] = useState("");
+  const [salonId, setSalonId] = useState("");
+  const [existingProducts, setExistingProducts] = useState<{ name: string }[]>([]);
+
+  const [rows, setRows] = useState<ProductRowValidation[]>([]);
+  const [encoding, setEncoding] = useState("");
+
+  const [resultSuccess, setResultSuccess] = useState(0);
+  const [resultFailed, setResultFailed] = useState(0);
+  const [resultErrors, setResultErrors] = useState<string[]>([]);
+  const [importProgress, setImportProgress] = useState(0);
+  const [importTotal, setImportTotal] = useState(0);
+
+  useEffect(() => { loadSalonData(); }, []);
+
+  const loadSalonData = async () => {
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    const { data: salon } = await supabase
+      .from("salons").select("id").eq("owner_id", user.id).single();
+    if (!salon) return;
+    setSalonId(salon.id);
+    const { data: products } = await supabase
+      .from("products").select("name").eq("salon_id", salon.id);
+    setExistingProducts(products ?? []);
+  };
+
+  const handleFileSelected = async (file: File) => {
+    setError("");
+    try {
+      const buffer = await file.arrayBuffer();
+      const { headers, rows: csvRows, encoding: enc } = parseCSV(buffer);
+      setEncoding(enc);
+      if (csvRows.length === 0) {
+        setError("データ行がありません");
+        return;
+      }
+      const validated = validateProductRows(headers, csvRows, existingProducts);
+      setRows(validated);
+      setStep("preview");
+    } catch {
+      setError("CSVの解析に失敗しました");
+    }
+  };
+
+  const handleToggleRow = (idx: number) => {
+    setRows((prev) => prev.map((r) =>
+      r.rowIndex === idx ? { ...r, checked: !r.checked } : r
+    ));
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    setRows((prev) => prev.map((r) =>
+      r.status !== "error" ? { ...r, checked } : r
+    ));
+  };
+
+  const handleImport = async () => {
+    const toImport = rows.filter((r) => r.checked);
+    setImportTotal(toImport.length);
+    setImportProgress(0);
+    setStep("importing");
+
+    const supabase = createClient();
+    let success = 0;
+    let failed = 0;
+    const errors: string[] = [];
+    const BATCH = 50;
+
+    for (let i = 0; i < toImport.length; i += BATCH) {
+      const batch = toImport.slice(i, i + BATCH);
+      const insertData = batch.map((r) => ({
+        salon_id: salonId,
+        name: r.data.name,
+        category: r.data.category,
+        base_sell_price: r.data.base_sell_price,
+        base_cost_price: r.data.base_cost_price,
+        reorder_point: r.data.reorder_point,
+        memo: r.data.memo,
+        is_active: true,
+      }));
+
+      const { data, error } = await supabase
+        .from("products").insert(insertData).select("id");
+
+      if (error) {
+        failed += batch.length;
+        errors.push(`行${i + 1}〜${i + batch.length}: ${error.message}`);
+      } else {
+        success += data?.length ?? 0;
+        failed += batch.length - (data?.length ?? 0);
+      }
+      setImportProgress(Math.min(i + BATCH, toImport.length));
+    }
+
+    setResultSuccess(success);
+    setResultFailed(failed);
+    setResultErrors(errors);
+    setStep("result");
+  };
+
+  const handleReset = () => {
+    setStep("upload");
+    setRows([]);
+    setError("");
+    setResultSuccess(0);
+    setResultFailed(0);
+    setResultErrors([]);
+    loadSalonData();
+  };
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="商品データ取り込み"
+        backLabel="データ取り込み"
+        backHref="/settings/import"
+        breadcrumbs={[
+          { label: "設定", href: "/settings" },
+          { label: "データ取り込み", href: "/settings/import" },
+          { label: "商品データ取り込み" },
+        ]}
+      />
+
+      {error && <ErrorAlert message={error} />}
+
+      {step === "upload" && (
+        <CsvUploadStep
+          title="商品データ取り込み"
+          templateDescription="テンプレートをダウンロードし、Excelで商品データを入力してCSV保存してください。「商品名」のみ必須です。"
+          templateFilename="商品インポートテンプレート.csv"
+          templateHeader={TEMPLATE_HEADER}
+          templateSample={TEMPLATE_SAMPLE}
+          onFileSelected={handleFileSelected}
+          error={error}
+        />
+      )}
+
+      {step === "preview" && (
+        <CsvPreviewTable
+          rows={rows}
+          columns={columns}
+          encoding={encoding}
+          onToggleRow={handleToggleRow}
+          onToggleAll={handleToggleAll}
+          onImport={handleImport}
+          onReset={handleReset}
+        />
+      )}
+
+      {step === "importing" && (
+        <CsvImportingStep progress={importProgress} total={importTotal} />
+      )}
+
+      {step === "result" && (
+        <CsvResultStep
+          successCount={resultSuccess}
+          failedCount={resultFailed}
+          errors={resultErrors}
+          primaryAction={{ label: "商品一覧を見る", href: "/sales/inventory/products" }}
+          secondaryAction={{ label: "続けて取り込む", onClick: handleReset }}
+          hubAction={{ label: "データ取り込みに戻る", href: "/settings/import" }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/import-records/loading.tsx
+++ b/src/app/(dashboard)/settings/import-records/loading.tsx
@@ -1,0 +1,16 @@
+export default function ImportRecordsLoading() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="h-8 bg-border rounded w-1/3" />
+      <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+        <div className="h-4 bg-border rounded w-1/2" />
+        <div className="h-3 bg-border rounded w-2/3" />
+        <div className="h-10 bg-border rounded w-1/3" />
+      </div>
+      <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+        <div className="h-4 bg-border rounded w-1/2" />
+        <div className="h-24 bg-border rounded" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/import-records/page.tsx
+++ b/src/app/(dashboard)/settings/import-records/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { CsvUploadStep } from "@/components/import/csv-upload-step";
+import { CsvPreviewTable, type ColumnDef } from "@/components/import/csv-preview-table";
+import { CsvImportingStep } from "@/components/import/csv-importing-step";
+import { CsvResultStep } from "@/components/import/csv-result-step";
+import { parseCSV } from "@/lib/csv-parse";
+import {
+  validateRecordRows,
+  type RecordRowValidation,
+  type ExistingCustomer,
+  type ExistingProduct,
+} from "@/lib/csv-import-records";
+
+type Step = "upload" | "preview" | "importing" | "result";
+
+const TEMPLATE_HEADER = "日付,お客様名,施術メニュー,施術料金,物販商品,物販金額,物販数量,メモ";
+const TEMPLATE_SAMPLE = "2024/3/15,山田 花子,カット,5000,,,初回来店";
+
+const columns: ColumnDef[] = [
+  { key: "date", label: "日付", render: (r: RecordRowValidation) => r.data.treatment_date },
+  { key: "customer", label: "顧客", render: (r: RecordRowValidation) => r.data.customer_match ?? r.data.customer_name },
+  { key: "menu", label: "メニュー", render: (r: RecordRowValidation) => r.data.menu_name || "-" },
+  { key: "price", label: "料金", render: (r: RecordRowValidation) => r.data.menu_price ? `¥${r.data.menu_price.toLocaleString()}` : "-" },
+  { key: "product", label: "物販", render: (r: RecordRowValidation) => r.data.purchase_item ?? "-" },
+];
+
+export default function ImportRecordsPage() {
+  const [step, setStep] = useState<Step>("upload");
+  const [error, setError] = useState("");
+  const [salonId, setSalonId] = useState("");
+  const [customers, setCustomers] = useState<ExistingCustomer[]>([]);
+  const [products, setProducts] = useState<ExistingProduct[]>([]);
+
+  const [rows, setRows] = useState<RecordRowValidation[]>([]);
+  const [encoding, setEncoding] = useState("");
+
+  const [resultSuccess, setResultSuccess] = useState(0);
+  const [resultFailed, setResultFailed] = useState(0);
+  const [resultErrors, setResultErrors] = useState<string[]>([]);
+  const [importProgress, setImportProgress] = useState(0);
+  const [importTotal, setImportTotal] = useState(0);
+
+  useEffect(() => { loadSalonData(); }, []);
+
+  const loadSalonData = async () => {
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    const { data: salon } = await supabase
+      .from("salons").select("id").eq("owner_id", user.id).single();
+    if (!salon) return;
+    setSalonId(salon.id);
+
+    const [custRes, prodRes] = await Promise.all([
+      supabase.from("customers")
+        .select("id, last_name, first_name, last_name_kana, first_name_kana")
+        .eq("salon_id", salon.id),
+      supabase.from("products")
+        .select("id, name, base_sell_price, base_cost_price")
+        .eq("salon_id", salon.id).eq("is_active", true),
+    ]);
+    setCustomers(custRes.data ?? []);
+    setProducts(prodRes.data ?? []);
+  };
+
+  const handleFileSelected = async (file: File) => {
+    setError("");
+    try {
+      const buffer = await file.arrayBuffer();
+      const { headers, rows: csvRows, encoding: enc } = parseCSV(buffer);
+      setEncoding(enc);
+      if (csvRows.length === 0) {
+        setError("データ行がありません");
+        return;
+      }
+      const validated = validateRecordRows(headers, csvRows, customers, products);
+      setRows(validated);
+      setStep("preview");
+    } catch {
+      setError("CSVの解析に失敗しました");
+    }
+  };
+
+  const handleToggleRow = (idx: number) => {
+    setRows((prev) => prev.map((r) =>
+      r.rowIndex === idx ? { ...r, checked: !r.checked } : r
+    ));
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    setRows((prev) => prev.map((r) =>
+      r.status !== "error" ? { ...r, checked } : r
+    ));
+  };
+
+  const handleImport = async () => {
+    const toImport = rows.filter((r) => r.checked);
+    setImportTotal(toImport.length);
+    setImportProgress(0);
+    setStep("importing");
+
+    const supabase = createClient();
+    let success = 0;
+    let failed = 0;
+    const errors: string[] = [];
+    const BATCH = 10;
+
+    for (let i = 0; i < toImport.length; i += BATCH) {
+      const batch = toImport.slice(i, i + BATCH);
+
+      for (const row of batch) {
+        try {
+          // 1. 施術記録を作成
+          const { data: record, error: recError } = await supabase
+            .from("treatment_records")
+            .insert({
+              salon_id: salonId,
+              customer_id: row.data.customer_id!,
+              treatment_date: row.data.treatment_date,
+              menu_name_snapshot: row.data.menu_name || null,
+              notes_after: row.data.memo,
+            })
+            .select("id")
+            .single();
+
+          if (recError || !record) {
+            failed++;
+            errors.push(`行${row.rowIndex + 1}: ${recError?.message ?? "登録失敗"}`);
+            continue;
+          }
+
+          // 2. メニュー情報を登録（treatment_record_menus）
+          if (row.data.menu_name) {
+            await supabase.from("treatment_record_menus").insert({
+              treatment_record_id: record.id,
+              menu_name_snapshot: row.data.menu_name,
+              price_snapshot: row.data.menu_price,
+              payment_type: "cash",
+              sort_order: 0,
+            });
+          }
+
+          // 3. 物販がある場合は purchases を作成
+          if (row.data.purchase_item) {
+            await supabase.from("purchases").insert({
+              salon_id: salonId,
+              customer_id: row.data.customer_id!,
+              purchase_date: row.data.treatment_date,
+              item_name: row.data.purchase_item,
+              quantity: row.data.purchase_quantity,
+              unit_price: row.data.purchase_price ?? 0,
+              total_price: (row.data.purchase_price ?? 0) * row.data.purchase_quantity,
+              product_id: row.data.purchase_product_id,
+              treatment_record_id: record.id,
+            });
+            // ※ 歴史的データなので inventory_logs は作成しない
+          }
+
+          success++;
+        } catch (e) {
+          failed++;
+          errors.push(`行${row.rowIndex + 1}: ${e instanceof Error ? e.message : "不明なエラー"}`);
+        }
+      }
+
+      setImportProgress(Math.min(i + BATCH, toImport.length));
+    }
+
+    setResultSuccess(success);
+    setResultFailed(failed);
+    setResultErrors(errors);
+    setStep("result");
+  };
+
+  const handleReset = () => {
+    setStep("upload");
+    setRows([]);
+    setError("");
+    setResultSuccess(0);
+    setResultFailed(0);
+    setResultErrors([]);
+    loadSalonData();
+  };
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="施術履歴取り込み"
+        backLabel="データ取り込み"
+        backHref="/settings/import"
+        breadcrumbs={[
+          { label: "設定", href: "/settings" },
+          { label: "データ取り込み", href: "/settings/import" },
+          { label: "施術履歴取り込み" },
+        ]}
+      />
+
+      {error && <ErrorAlert message={error} />}
+
+      {step === "upload" && (
+        <CsvUploadStep
+          title="施術履歴取り込み"
+          templateDescription="テンプレートをダウンロードし、施術履歴を入力してCSV保存してください。「日付」と「お客様名」が必須です。お客様名は顧客マスタに登録済みの名前と一致させてください。"
+          templateFilename="施術履歴インポートテンプレート.csv"
+          templateHeader={TEMPLATE_HEADER}
+          templateSample={TEMPLATE_SAMPLE}
+          onFileSelected={handleFileSelected}
+          error={error}
+          notes={
+            <>
+              <p>💡 1行が1つのカルテになります。複数メニューは「カット、カラー」のようにまとめて入力してください。</p>
+              <p className="mt-1">💡 物販欄の商品が商品マスタに登録済みなら在庫と連携します（過去データは在庫数に影響しません）。</p>
+            </>
+          }
+        />
+      )}
+
+      {step === "preview" && (
+        <CsvPreviewTable
+          rows={rows}
+          columns={columns}
+          encoding={encoding}
+          onToggleRow={handleToggleRow}
+          onToggleAll={handleToggleAll}
+          onImport={handleImport}
+          onReset={handleReset}
+        />
+      )}
+
+      {step === "importing" && (
+        <CsvImportingStep progress={importProgress} total={importTotal} />
+      )}
+
+      {step === "result" && (
+        <CsvResultStep
+          successCount={resultSuccess}
+          failedCount={resultFailed}
+          errors={resultErrors}
+          primaryAction={{ label: "カルテ一覧を見る", href: "/records" }}
+          secondaryAction={{ label: "続けて取り込む", onClick: handleReset }}
+          hubAction={{ label: "データ取り込みに戻る", href: "/settings/import" }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/import/loading.tsx
+++ b/src/app/(dashboard)/settings/import/loading.tsx
@@ -1,0 +1,22 @@
+export default function ImportHubLoading() {
+  return (
+    <div className="space-y-5 animate-pulse">
+      <div className="h-8 bg-border rounded w-1/3" />
+      <div className="bg-surface border border-border rounded-2xl p-4">
+        <div className="h-4 bg-border rounded w-2/3 mb-2" />
+        <div className="h-3 bg-border rounded w-1/2" />
+      </div>
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="bg-surface border border-border rounded-2xl p-4">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 rounded-full bg-border" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-border rounded w-1/3" />
+              <div className="h-3 bg-border rounded w-2/3" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/import/page.tsx
+++ b/src/app/(dashboard)/settings/import/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { ImportStepCard } from "@/components/import/import-step-card";
+
+export default function ImportHubPage() {
+  const [loading, setLoading] = useState(true);
+  const [counts, setCounts] = useState({ customers: 0, products: 0, records: 0 });
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: salon } = await supabase
+        .from("salons")
+        .select("id")
+        .eq("owner_id", user.id)
+        .single();
+      if (!salon) return;
+
+      const [custRes, prodRes, recRes] = await Promise.all([
+        supabase.from("customers").select("*", { count: "exact", head: true }).eq("salon_id", salon.id),
+        supabase.from("products").select("*", { count: "exact", head: true }).eq("salon_id", salon.id),
+        supabase.from("treatment_records").select("*", { count: "exact", head: true }).eq("salon_id", salon.id),
+      ]);
+
+      setCounts({
+        customers: custRes.count ?? 0,
+        products: prodRes.count ?? 0,
+        records: recRes.count ?? 0,
+      });
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  // ステップ状態の判定
+  const step1Status = counts.customers > 0 ? "done" as const : "available" as const;
+  const step2Status = counts.products > 0 ? "done" as const : "skippable" as const;
+  const step3Status = counts.customers === 0 && !loading
+    ? "locked" as const
+    : counts.records > 0
+      ? "done" as const
+      : "available" as const;
+
+  return (
+    <div className="space-y-5">
+      <PageHeader
+        title="データ取り込み"
+        backHref="/settings"
+        breadcrumbs={[
+          { label: "設定", href: "/settings" },
+          { label: "データ取り込み" },
+        ]}
+      />
+
+      {/* ガイド文 */}
+      <div className="bg-accent/5 border border-accent/20 rounded-2xl p-4">
+        <p className="text-sm">
+          Excelの既存データをCSVファイルで一括取り込みできます。
+        </p>
+        <p className="text-sm text-text-light mt-1">
+          上から順番に進めてください。
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-surface border border-border rounded-2xl p-4 animate-pulse">
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-full bg-border" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 bg-border rounded w-1/3" />
+                  <div className="h-3 bg-border rounded w-2/3" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <ImportStepCard
+            stepNumber={1}
+            title="顧客マスタ"
+            description="お客様の基本情報（氏名・連絡先・生年月日など）"
+            status={step1Status}
+            href="/settings/import-customers"
+            count={counts.customers > 0 ? counts.customers : undefined}
+          />
+          <ImportStepCard
+            stepNumber={2}
+            title="商品マスタ"
+            description="物販商品のマスタデータ（商品名・販売価格・仕入価格）"
+            status={step2Status}
+            href="/settings/import-products"
+            count={counts.products > 0 ? counts.products : undefined}
+            skipNote="物販がない場合はスキップできます"
+          />
+          <ImportStepCard
+            stepNumber={3}
+            title="施術履歴"
+            description="過去の施術記録（日付・お客様名・メニュー・料金・物販）"
+            status={step3Status}
+            href="/settings/import-records"
+            count={counts.records > 0 ? counts.records : undefined}
+            lockReason="先に顧客データを取り込んでください"
+          />
+        </div>
+      )}
+
+      {/* 注意事項 */}
+      <div className="text-xs text-text-light bg-background rounded-xl p-3 space-y-1">
+        <p>💡 ExcelファイルはCSV形式で保存してからアップロードしてください。</p>
+        <p>💡 在庫数は取り込まれません。取り込み後に「棚卸し」で現在の在庫数を設定してください。</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -175,16 +175,16 @@ export default function SettingsPage() {
         </div>
       </Link>
 
-      {/* Import customers link */}
+      {/* Import hub link */}
       <Link
-        href="/settings/import-customers"
+        href="/settings/import"
         className="block bg-surface border border-border rounded-2xl p-5 hover:border-accent transition-colors"
       >
         <div className="flex justify-between items-center">
           <div>
-            <h3 className="font-bold">顧客データ取り込み</h3>
+            <h3 className="font-bold">データ取り込み</h3>
             <p className="text-sm text-text-light mt-1">
-              CSVファイルから顧客を一括登録
+              顧客・商品・施術履歴をCSVで一括登録
             </p>
           </div>
           <span className="text-text-light">→</span>

--- a/src/components/import/csv-importing-step.tsx
+++ b/src/components/import/csv-importing-step.tsx
@@ -1,0 +1,35 @@
+export function CsvImportingStep({
+  progress,
+  total,
+  label = "取り込み中...",
+}: {
+  progress: number;
+  total: number;
+  label?: string;
+}) {
+  const percent = total > 0 ? Math.round((progress / total) * 100) : 0;
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 space-y-6">
+      {/* スピナー */}
+      <div className="w-12 h-12 border-4 border-border border-t-accent rounded-full animate-spin" />
+
+      <div className="text-center space-y-1">
+        <p className="font-bold">{label}</p>
+        <p className="text-sm text-text-light">
+          {progress} / {total} 件
+        </p>
+      </div>
+
+      {/* プログレスバー */}
+      <div className="w-full max-w-xs">
+        <div className="w-full bg-border rounded-full h-2">
+          <div
+            className="bg-accent rounded-full h-2 transition-all duration-300"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/import/csv-preview-table.tsx
+++ b/src/components/import/csv-preview-table.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+export type ColumnDef = {
+  key: string;
+  label: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (row: any) => React.ReactNode;
+};
+
+export type BaseRow = {
+  rowIndex: number;
+  status: "ok" | "warning" | "error" | "skip";
+  messages: string[];
+  isDuplicate: boolean;
+  checked: boolean;
+};
+
+export function CsvPreviewTable<T extends BaseRow>({
+  rows,
+  columns,
+  encoding,
+  onToggleRow,
+  onToggleAll,
+  onImport,
+  onReset,
+}: {
+  rows: T[];
+  columns: ColumnDef[];
+  encoding: string;
+  onToggleRow: (rowIndex: number) => void;
+  onToggleAll: (checked: boolean) => void;
+  onImport: () => void;
+  onReset: () => void;
+}) {
+  const checkedCount = rows.filter((r) => r.checked).length;
+  const errorCount = rows.filter((r) => r.status === "error").length;
+  const duplicateCount = rows.filter((r) => r.isDuplicate).length;
+
+  return (
+    <div className="space-y-4">
+      {/* サマリー */}
+      <div className="bg-surface border border-border rounded-2xl p-4">
+        <div className="grid grid-cols-2 gap-2 text-center text-sm">
+          <div>
+            <p className="text-lg font-bold">{rows.length}</p>
+            <p className="text-xs text-text-light">全件数</p>
+          </div>
+          <div>
+            <p className="text-lg font-bold text-accent">{checkedCount}</p>
+            <p className="text-xs text-text-light">取り込み対象</p>
+          </div>
+          {errorCount > 0 && (
+            <div>
+              <p className="text-lg font-bold text-red-500">{errorCount}</p>
+              <p className="text-xs text-text-light">エラー</p>
+            </div>
+          )}
+          {duplicateCount > 0 && (
+            <div>
+              <p className="text-lg font-bold text-orange-500">{duplicateCount}</p>
+              <p className="text-xs text-text-light">重複</p>
+            </div>
+          )}
+        </div>
+        <p className="text-[10px] text-text-light text-center mt-2">
+          文字コード: {encoding}
+        </p>
+      </div>
+
+      {/* 一括操作 */}
+      <div className="flex gap-2">
+        <button
+          onClick={() => onToggleAll(true)}
+          className="text-xs text-accent border border-accent rounded-lg px-3 py-1.5 hover:bg-accent/5"
+        >
+          全て選択
+        </button>
+        <button
+          onClick={() => onToggleAll(false)}
+          className="text-xs text-text-light border border-border rounded-lg px-3 py-1.5 hover:bg-background"
+        >
+          全て解除
+        </button>
+      </div>
+
+      {/* テーブル */}
+      <div className="overflow-x-auto -mx-4 px-4">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="py-2 px-1 text-left w-8"></th>
+              <th className="py-2 px-1 text-left w-8">行</th>
+              {columns.map((col) => (
+                <th key={col.key} className="py-2 px-2 text-left whitespace-nowrap">
+                  {col.label}
+                </th>
+              ))}
+              <th className="py-2 px-2 text-left">状態</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.rowIndex}
+                className={`border-b border-border/50 ${
+                  row.status === "error"
+                    ? "bg-red-50"
+                    : row.isDuplicate
+                      ? "bg-orange-50"
+                      : row.checked
+                        ? ""
+                        : "opacity-50"
+                }`}
+              >
+                <td className="py-2 px-1">
+                  <input
+                    type="checkbox"
+                    checked={row.checked}
+                    disabled={row.status === "error"}
+                    onChange={() => onToggleRow(row.rowIndex)}
+                    className="w-4 h-4"
+                  />
+                </td>
+                <td className="py-2 px-1 text-text-light">{row.rowIndex + 1}</td>
+                {columns.map((col) => (
+                  <td key={col.key} className="py-2 px-2 whitespace-nowrap max-w-[120px] truncate">
+                    {col.render(row)}
+                  </td>
+                ))}
+                <td className="py-2 px-2">
+                  {row.status === "error" && (
+                    <span className="text-red-500" title={row.messages.join(", ")}>❌</span>
+                  )}
+                  {row.status === "warning" && (
+                    <span className="text-orange-500" title={row.messages.join(", ")}>⚠️</span>
+                  )}
+                  {row.status === "ok" && !row.isDuplicate && (
+                    <span className="text-success">✓</span>
+                  )}
+                  {row.isDuplicate && (
+                    <span className="text-orange-500">重複</span>
+                  )}
+                  {row.messages.length > 0 && (
+                    <p className="text-[10px] text-text-light mt-0.5 whitespace-normal">
+                      {row.messages[0]}
+                    </p>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex gap-3">
+        <button
+          onClick={onReset}
+          className="flex-1 border border-border text-sm font-medium py-3 rounded-xl hover:bg-background transition-colors"
+        >
+          やり直す
+        </button>
+        <button
+          onClick={onImport}
+          disabled={checkedCount === 0}
+          className="flex-1 bg-accent text-white text-sm font-medium py-3 rounded-xl hover:bg-accent/90 transition-colors disabled:opacity-50"
+        >
+          {checkedCount}件を取り込む
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/import/csv-result-step.tsx
+++ b/src/components/import/csv-result-step.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+
+export function CsvResultStep({
+  successCount,
+  failedCount,
+  errors,
+  primaryAction,
+  secondaryAction,
+  hubAction,
+}: {
+  successCount: number;
+  failedCount: number;
+  errors: string[];
+  primaryAction: { label: string; href: string };
+  secondaryAction: { label: string; onClick: () => void };
+  hubAction?: { label: string; href: string };
+}) {
+  return (
+    <div className="space-y-4">
+      {/* 成功 */}
+      {successCount > 0 && (
+        <div className="bg-green-50 border border-green-200 rounded-2xl p-5 text-center">
+          <div className="w-12 h-12 rounded-full bg-success/10 flex items-center justify-center mx-auto mb-3">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6 text-success">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+            </svg>
+          </div>
+          <p className="text-lg font-bold text-success">{successCount}件を登録しました</p>
+        </div>
+      )}
+
+      {/* 失敗 */}
+      {failedCount > 0 && (
+        <div className="bg-red-50 border border-red-200 rounded-2xl p-4 space-y-2">
+          <p className="text-sm font-bold text-red-700">{failedCount}件が失敗しました</p>
+          <div className="space-y-1 max-h-32 overflow-y-auto">
+            {errors.map((err, i) => (
+              <p key={i} className="text-xs text-red-600">{err}</p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* アクション */}
+      <div className="space-y-2 pt-2">
+        <Link
+          href={primaryAction.href}
+          className="block w-full bg-accent text-white text-sm font-medium py-3 rounded-xl text-center hover:bg-accent/90 transition-colors"
+        >
+          {primaryAction.label}
+        </Link>
+        <button
+          onClick={secondaryAction.onClick}
+          className="block w-full border border-border text-sm font-medium py-3 rounded-xl text-center hover:bg-background transition-colors"
+        >
+          {secondaryAction.label}
+        </button>
+        {hubAction && (
+          <Link
+            href={hubAction.href}
+            className="block w-full text-sm text-accent text-center py-2 hover:underline"
+          >
+            {hubAction.label}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/import/csv-upload-step.tsx
+++ b/src/components/import/csv-upload-step.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRef } from "react";
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+
+export function CsvUploadStep({
+  title,
+  templateDescription,
+  templateFilename,
+  templateHeader,
+  templateSample,
+  onFileSelected,
+  error,
+  notes,
+}: {
+  title: string;
+  templateDescription: string;
+  templateFilename: string;
+  templateHeader: string;
+  templateSample: string;
+  onFileSelected: (file: File) => void;
+  error?: string;
+  notes?: React.ReactNode;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const downloadTemplate = () => {
+    const bom = "\uFEFF";
+    const csv = bom + templateHeader + "\n" + templateSample + "\n";
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = templateFilename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.name.endsWith(".csv")) {
+      alert("CSVファイルを選択してください");
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      alert("ファイルサイズが1MBを超えています");
+      return;
+    }
+    onFileSelected(file);
+    // inputをリセットして同じファイルを再選択可能に
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* テンプレートダウンロード */}
+      <div className="bg-accent/5 border border-accent/20 rounded-2xl p-4 space-y-3">
+        <h3 className="font-bold text-sm">1. テンプレートをダウンロード</h3>
+        <p className="text-xs text-text-light">{templateDescription}</p>
+        <button
+          onClick={downloadTemplate}
+          className="bg-accent text-white text-sm font-medium px-4 py-2.5 rounded-xl hover:bg-accent/90 transition-colors"
+        >
+          テンプレートをダウンロード
+        </button>
+      </div>
+
+      {/* ファイル選択 */}
+      <div className="bg-surface border border-border rounded-2xl p-4 space-y-3">
+        <h3 className="font-bold text-sm">2. CSVファイルを選択</h3>
+        <p className="text-xs text-text-light">
+          テンプレートにデータを入力し、CSV形式で保存してからアップロードしてください。
+        </p>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="w-full border-2 border-dashed border-border rounded-xl p-6 text-center hover:border-accent transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8 mx-auto text-text-light mb-2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+          </svg>
+          <p className="text-sm font-medium">タップしてCSVファイルを選択</p>
+          <p className="text-xs text-text-light mt-1">最大1MB</p>
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </div>
+
+      {notes && (
+        <div className="text-xs text-text-light bg-background rounded-xl p-3">
+          {notes}
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/import/import-step-card.tsx
+++ b/src/components/import/import-step-card.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+
+type Status = "done" | "available" | "skippable" | "locked";
+
+export function ImportStepCard({
+  stepNumber,
+  title,
+  description,
+  status,
+  href,
+  count,
+  lockReason,
+  skipNote,
+}: {
+  stepNumber: number;
+  title: string;
+  description: string;
+  status: Status;
+  href: string;
+  count?: number;
+  lockReason?: string;
+  skipNote?: string;
+}) {
+  const isClickable = status !== "locked";
+
+  const content = (
+    <div
+      className={`border rounded-2xl p-4 transition-colors ${
+        status === "done"
+          ? "bg-green-50 border-green-200"
+          : status === "locked"
+            ? "bg-gray-50 border-border opacity-60"
+            : "bg-surface border-border hover:border-accent"
+      }`}
+    >
+      <div className="flex items-start gap-4">
+        {/* ステップ番号 */}
+        <div
+          className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 text-sm font-bold ${
+            status === "done"
+              ? "bg-success text-white"
+              : status === "locked"
+                ? "bg-border text-text-light"
+                : "bg-accent/10 text-accent"
+          }`}
+        >
+          {status === "done" ? (
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-5 h-5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+            </svg>
+          ) : (
+            stepNumber
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <h3 className="font-bold">{title}</h3>
+            {isClickable && (
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-text-light shrink-0">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+              </svg>
+            )}
+          </div>
+          <p className="text-sm text-text-light mt-0.5">{description}</p>
+
+          {status === "done" && count !== undefined && (
+            <p className="text-xs text-success font-medium mt-1.5">{count}件登録済み</p>
+          )}
+          {status === "locked" && lockReason && (
+            <p className="text-xs text-text-light mt-1.5">🔒 {lockReason}</p>
+          )}
+          {status === "skippable" && skipNote && (
+            <p className="text-xs text-text-light mt-1.5">{skipNote}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (isClickable) {
+    return <Link href={href}>{content}</Link>;
+  }
+  return content;
+}

--- a/src/lib/csv-import-products.ts
+++ b/src/lib/csv-import-products.ts
@@ -1,0 +1,136 @@
+/**
+ * 商品CSVインポート — 検証ロジック
+ */
+
+export type ProductRow = {
+  name: string;
+  category: string | null;
+  base_sell_price: number;
+  base_cost_price: number;
+  reorder_point: number;
+  memo: string | null;
+};
+
+export type ProductRowValidation = {
+  rowIndex: number;
+  status: "ok" | "warning" | "error" | "skip";
+  messages: string[];
+  data: ProductRow;
+  isDuplicate: boolean;
+  duplicateMatch?: string;
+  checked: boolean;
+};
+
+// ヘッダー名 → 内部カラム名のマッピング
+const HEADER_MAP: Record<string, string> = {
+  "商品名": "name",
+  "商品": "name",
+  "名前": "name",
+  "カテゴリ": "category",
+  "分類": "category",
+  "販売価格": "sell_price",
+  "売価": "sell_price",
+  "販売単価": "sell_price",
+  "仕入価格": "cost_price",
+  "仕入": "cost_price",
+  "原価": "cost_price",
+  "仕入単価": "cost_price",
+  "発注点": "reorder_point",
+  "メモ": "memo",
+  "備考": "memo",
+};
+
+export function detectProductColumns(headers: string[]): Record<string, number> {
+  const map: Record<string, number> = {};
+  headers.forEach((h, i) => {
+    const trimmed = h.trim();
+    const col = HEADER_MAP[trimmed];
+    if (col && !(col in map)) {
+      map[col] = i;
+    }
+  });
+  return map;
+}
+
+function parsePrice(value: string): number | null {
+  if (!value.trim()) return null;
+  // カンマ・円記号を除去
+  const cleaned = value.replace(/[,，¥￥円]/g, "").trim();
+  const num = parseInt(cleaned, 10);
+  return isNaN(num) ? null : num;
+}
+
+export function validateProductRows(
+  headers: string[],
+  rows: string[][],
+  existingProducts: { name: string }[],
+): ProductRowValidation[] {
+  const colMap = detectProductColumns(headers);
+  const existingNames = new Set(
+    existingProducts.map((p) => p.name.trim().toLowerCase())
+  );
+
+  return rows.map((row, i) => {
+    const messages: string[] = [];
+    let status: "ok" | "warning" | "error" = "ok";
+    let isDuplicate = false;
+
+    // 商品名（必須）
+    const nameIdx = colMap["name"];
+    const name = nameIdx !== undefined ? (row[nameIdx] ?? "").trim() : "";
+    if (!name) {
+      messages.push("商品名が空です");
+      status = "error";
+    }
+
+    // 重複チェック
+    if (name && existingNames.has(name.toLowerCase())) {
+      isDuplicate = true;
+      messages.push(`「${name}」は登録済みです`);
+    }
+
+    // 販売価格
+    const sellRaw = colMap["sell_price"] !== undefined ? (row[colMap["sell_price"]] ?? "") : "";
+    const sellPrice = parsePrice(sellRaw);
+    if (sellRaw.trim() && sellPrice === null) {
+      messages.push("販売価格が不正です");
+      status = "error";
+    }
+
+    // 仕入価格
+    const costRaw = colMap["cost_price"] !== undefined ? (row[colMap["cost_price"]] ?? "") : "";
+    const costPrice = parsePrice(costRaw);
+    if (costRaw.trim() && costPrice === null) {
+      messages.push("仕入価格が不正です");
+      status = "error";
+    }
+
+    // 発注点
+    const reorderRaw = colMap["reorder_point"] !== undefined ? (row[colMap["reorder_point"]] ?? "") : "";
+    const reorderPoint = reorderRaw.trim() ? parseInt(reorderRaw.trim(), 10) : 3;
+    if (reorderRaw.trim() && isNaN(reorderPoint)) {
+      messages.push("発注点が不正です");
+      if (status !== "error") status = "warning";
+    }
+
+    // カテゴリ・メモ
+    const category = colMap["category"] !== undefined ? (row[colMap["category"]] ?? "").trim() || null : null;
+    const memo = colMap["memo"] !== undefined ? (row[colMap["memo"]] ?? "").trim() || null : null;
+
+    return {
+      rowIndex: i,
+      status,
+      messages,
+      isDuplicate,
+      checked: status !== "error" && !isDuplicate,
+      data: {
+        name,
+        category,
+        base_sell_price: sellPrice ?? 0,
+        base_cost_price: costPrice ?? 0,
+        reorder_point: isNaN(reorderPoint) ? 3 : reorderPoint,
+        memo,
+      },
+    };
+  });
+}

--- a/src/lib/csv-import-records.ts
+++ b/src/lib/csv-import-records.ts
@@ -1,0 +1,282 @@
+/**
+ * 施術履歴CSVインポート — 検証ロジック
+ */
+import { splitName, parseBirthDate } from "./csv-parse";
+
+// parseBirthDate は日付パーサーとして汎用的に使える（YYYY/M/D, YYYY-M-D, YYYY年M月D日）
+const parseDate = parseBirthDate;
+
+export type RecordRow = {
+  treatment_date: string;       // YYYY-MM-DD
+  customer_name: string;        // CSV上の元の名前
+  customer_id: string | null;   // 解決されたID
+  customer_match: string | null;// マッチした顧客の表示名
+  menu_name: string;            // メニュー名テキスト
+  menu_price: number | null;    // 料金
+  purchase_item: string | null; // 物販商品名
+  purchase_price: number | null;
+  purchase_quantity: number;
+  purchase_product_id: string | null; // 商品マスタから解決
+  memo: string | null;
+};
+
+export type RecordRowValidation = {
+  rowIndex: number;
+  status: "ok" | "warning" | "error" | "skip";
+  messages: string[];
+  data: RecordRow;
+  isDuplicate: boolean;
+  checked: boolean;
+};
+
+export type ExistingCustomer = {
+  id: string;
+  last_name: string;
+  first_name: string;
+  last_name_kana: string | null;
+  first_name_kana: string | null;
+};
+
+export type ExistingProduct = {
+  id: string;
+  name: string;
+  base_sell_price: number;
+  base_cost_price: number;
+};
+
+// ヘッダー名マッピング
+const HEADER_MAP: Record<string, string> = {
+  "日付": "date",
+  "来店日": "date",
+  "施術日": "date",
+  "お客様名": "customer",
+  "お客様": "customer",
+  "顧客名": "customer",
+  "氏名": "customer",
+  "名前": "customer",
+  "施術メニュー": "menu",
+  "メニュー": "menu",
+  "施術内容": "menu",
+  "施術料金": "price",
+  "料金": "price",
+  "金額": "price",
+  "物販商品": "product",
+  "物販": "product",
+  "商品": "product",
+  "商品名": "product",
+  "物販金額": "product_price",
+  "物販単価": "product_price",
+  "物販数量": "product_qty",
+  "数量": "product_qty",
+  "メモ": "memo",
+  "備考": "memo",
+};
+
+export function detectRecordColumns(headers: string[]): Record<string, number> {
+  const map: Record<string, number> = {};
+  headers.forEach((h, i) => {
+    const trimmed = h.trim();
+    const col = HEADER_MAP[trimmed];
+    if (col && !(col in map)) {
+      map[col] = i;
+    }
+  });
+  return map;
+}
+
+function parsePrice(value: string): number | null {
+  if (!value.trim()) return null;
+  const cleaned = value.replace(/[,，¥￥円]/g, "").trim();
+  const num = parseInt(cleaned, 10);
+  return isNaN(num) ? null : num;
+}
+
+/** 顧客名からIDを解決 */
+function resolveCustomer(
+  rawName: string,
+  customers: ExistingCustomer[],
+): { id: string | null; displayName: string | null; message: string | null } {
+  const { last, first } = splitName(rawName);
+  if (!last) {
+    return { id: null, displayName: null, message: "お客様名が空です" };
+  }
+
+  // 1. 姓名完全一致
+  const exact = customers.filter(
+    (c) => c.last_name === last && c.first_name === (first || "")
+  );
+  if (exact.length === 1) {
+    return { id: exact[0].id, displayName: `${exact[0].last_name} ${exact[0].first_name}`, message: null };
+  }
+  if (exact.length > 1) {
+    return { id: exact[0].id, displayName: `${exact[0].last_name} ${exact[0].first_name}`, message: `同名の顧客が${exact.length}名います` };
+  }
+
+  // 2. スペースなし連結一致（CSV上で「山田花子」のようにスペースなしの場合）
+  const fullName = last + (first || "");
+  const concat = customers.filter(
+    (c) => (c.last_name + c.first_name) === fullName
+  );
+  if (concat.length === 1) {
+    return { id: concat[0].id, displayName: `${concat[0].last_name} ${concat[0].first_name}`, message: null };
+  }
+  if (concat.length > 1) {
+    return { id: concat[0].id, displayName: `${concat[0].last_name} ${concat[0].first_name}`, message: `同名の顧客が${concat.length}名います` };
+  }
+
+  // 3. カナ一致
+  if (first) {
+    const kana = customers.filter(
+      (c) => c.last_name_kana === last && c.first_name_kana === first
+    );
+    if (kana.length === 1) {
+      return { id: kana[0].id, displayName: `${kana[0].last_name} ${kana[0].first_name}`, message: "カナで一致" };
+    }
+  }
+
+  // 4. 姓のみ一致（名がCSVにない場合）
+  if (!first) {
+    const lastOnly = customers.filter((c) => c.last_name === last);
+    if (lastOnly.length === 1) {
+      return { id: lastOnly[0].id, displayName: `${lastOnly[0].last_name} ${lastOnly[0].first_name}`, message: "姓のみで一致" };
+    }
+    if (lastOnly.length > 1) {
+      return { id: null, displayName: null, message: `「${last}」が${lastOnly.length}名います。名前も入力してください` };
+    }
+  }
+
+  return { id: null, displayName: null, message: `顧客が見つかりません: ${rawName}` };
+}
+
+/** 商品名からIDを解決 */
+function resolveProduct(
+  name: string,
+  products: ExistingProduct[],
+): { id: string | null; sellPrice: number; costPrice: number; message: string | null } {
+  const trimmed = name.trim().toLowerCase();
+  const match = products.find((p) => p.name.trim().toLowerCase() === trimmed);
+  if (match) {
+    return { id: match.id, sellPrice: match.base_sell_price, costPrice: match.base_cost_price, message: null };
+  }
+  return { id: null, sellPrice: 0, costPrice: 0, message: `商品マスタに未登録: ${name}（在庫連動なし）` };
+}
+
+export function validateRecordRows(
+  headers: string[],
+  rows: string[][],
+  existingCustomers: ExistingCustomer[],
+  existingProducts: ExistingProduct[],
+): RecordRowValidation[] {
+  const colMap = detectRecordColumns(headers);
+
+  // 重複検出用マップ
+  const seen = new Map<string, number>();
+
+  return rows.map((row, i) => {
+    const messages: string[] = [];
+    let status: "ok" | "warning" | "error" = "ok";
+    let isDuplicate = false;
+
+    // 日付（必須）
+    const dateRaw = colMap["date"] !== undefined ? (row[colMap["date"]] ?? "").trim() : "";
+    const treatmentDate = dateRaw ? parseDate(dateRaw) : null;
+    if (!dateRaw) {
+      messages.push("日付が空です");
+      status = "error";
+    } else if (!treatmentDate) {
+      messages.push("日付の形式が不正です");
+      status = "error";
+    }
+
+    // 顧客名（必須）
+    const customerRaw = colMap["customer"] !== undefined ? (row[colMap["customer"]] ?? "").trim() : "";
+    const resolved = resolveCustomer(customerRaw, existingCustomers);
+    if (!resolved.id) {
+      if (status !== "error") status = "error";
+      messages.push(resolved.message ?? "顧客が見つかりません");
+    } else if (resolved.message) {
+      if (status !== "error") status = "warning";
+      messages.push(resolved.message);
+    }
+
+    // メニュー名
+    const menuName = colMap["menu"] !== undefined ? (row[colMap["menu"]] ?? "").trim() : "";
+    if (!menuName) {
+      if (status !== "error") status = "warning";
+      messages.push("メニュー名が空です");
+    }
+
+    // 料金
+    const priceRaw = colMap["price"] !== undefined ? (row[colMap["price"]] ?? "") : "";
+    const menuPrice = parsePrice(priceRaw);
+    if (priceRaw.trim() && menuPrice === null) {
+      messages.push("料金が不正です");
+      if (status !== "error") status = "warning";
+    }
+
+    // 物販商品
+    const productRaw = colMap["product"] !== undefined ? (row[colMap["product"]] ?? "").trim() : "";
+    let purchaseProductId: string | null = null;
+    let purchasePrice: number | null = null;
+    let purchaseQty = 1;
+
+    if (productRaw) {
+      const prodResolved = resolveProduct(productRaw, existingProducts);
+      purchaseProductId = prodResolved.id;
+      if (prodResolved.message) {
+        if (status !== "error") status = "warning";
+        messages.push(prodResolved.message);
+      }
+
+      // 物販金額
+      const ppRaw = colMap["product_price"] !== undefined ? (row[colMap["product_price"]] ?? "") : "";
+      purchasePrice = parsePrice(ppRaw);
+      if (!purchasePrice && prodResolved.id) {
+        // 商品マスタの売価を使用
+        purchasePrice = prodResolved.sellPrice;
+      }
+
+      // 物販数量
+      const pqRaw = colMap["product_qty"] !== undefined ? (row[colMap["product_qty"]] ?? "") : "";
+      if (pqRaw.trim()) {
+        const q = parseInt(pqRaw.trim(), 10);
+        if (!isNaN(q) && q > 0) purchaseQty = q;
+      }
+    }
+
+    // メモ
+    const memo = colMap["memo"] !== undefined ? (row[colMap["memo"]] ?? "").trim() || null : null;
+
+    // 重複検出（同日+同顧客+同メニュー）
+    if (resolved.id && treatmentDate) {
+      const key = `${treatmentDate}|${resolved.id}|${menuName}`;
+      if (seen.has(key)) {
+        isDuplicate = true;
+        messages.push(`CSV内で重複: 行${(seen.get(key)! + 1)}と同じ`);
+        if (status !== "error") status = "warning";
+      }
+      seen.set(key, i);
+    }
+
+    return {
+      rowIndex: i,
+      status,
+      messages,
+      isDuplicate,
+      checked: status !== "error" && !isDuplicate,
+      data: {
+        treatment_date: treatmentDate ?? "",
+        customer_name: customerRaw,
+        customer_id: resolved.id,
+        customer_match: resolved.displayName,
+        menu_name: menuName,
+        menu_price: menuPrice,
+        purchase_item: productRaw || null,
+        purchase_price: purchasePrice,
+        purchase_quantity: purchaseQty,
+        purchase_product_id: purchaseProductId,
+        memo,
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- 設定画面に「データ取り込み」ハブを新設。3ステップの依存関係を視覚的にガイド
- **STEP 1**: 顧客マスタ（既存機能をハブに統合）
- **STEP 2**: 商品マスタ（新規）— 商品名・カテゴリ・販売/仕入価格
- **STEP 3**: 施術履歴（新規）— 日付・顧客名→ID解決・メニュー・料金・物販連携
- 共通コンポーネント5つで3つのウィザードのUIを統一
- DB変更なし（マイグレーション不要）

## Test plan
- [ ] `/settings` → 「データ取り込み」→ ハブ画面が表示されること
- [ ] ステップ状態（完了/取り込み可能/スキップ可能/ロック）が正しいこと
- [ ] 既存の顧客インポートがハブ経由で動作すること
- [ ] 商品テンプレDL → Excel記入 → CSV保存 → アップロード → プレビュー → インポート
- [ ] 施術履歴テンプレDL → 記入 → アップロード → 顧客名解決確認 → インポート
- [ ] 顧客が0件の場合、施術履歴がロック状態になること
- [ ] 物販欄の商品が商品マスタにマッチした場合product_idがセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)