### PR TITLE
fix: iPad/iOSでCSVファイルが選択できない問題を修正

### DIFF
--- a/src/components/import/csv-upload-step.tsx
+++ b/src/components/import/csv-upload-step.tsx
@@ -86,7 +86,7 @@ export function CsvUploadStep({
         <input
           ref={fileInputRef}
           type="file"
-          accept=".csv"
+          accept=".csv,text/csv,text/comma-separated-values,application/csv,application/vnd.ms-excel"
           onChange={handleFileChange}
           className="hidden"
         />


### PR DESCRIPTION
## Summary
- CSVファイルアップロードの`accept`属性を拡張し、複数のMIMEタイプに対応
- iOS/iPadOSのファイルピッカーで`.csv`拡張子だけではファイルがグレーアウトされる問題を解消
- 顧客・商品・施術履歴の全インポート画面に適用（共通コンポーネント修正）

## Test plan
- [ ] iPadからCSVファイルを選択できることを確認
- [ ] iPhoneからCSVファイルを選択できることを確認
- [ ] PC（Chrome/Safari）で従来通りCSV選択可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)