### PR TITLE
perf: 施術写真パフォーマンス最適化

### DIFF
--- a/src/app/(dashboard)/records/[id]/page.tsx
+++ b/src/app/(dashboard)/records/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function RecordDetailPage({
       .single<RecordWithCustomer>(),
     supabase
       .from("treatment_photos")
-      .select("id, treatment_record_id, storage_path, photo_type, description")
+      .select("id, treatment_record_id, storage_path, photo_type, memo")
       .eq("treatment_record_id", id)
       .order("photo_type")
       .returns<TreatmentPhoto[]>(),

--- a/src/components/records/before-after.tsx
+++ b/src/components/records/before-after.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getPhotoUrl } from "@/lib/supabase/storage";
+import { getPhotoUrls } from "@/lib/supabase/storage";
 import type { Database } from "@/types/database";
 
 type TreatmentPhoto = Database["public"]["Tables"]["treatment_photos"]["Row"];
@@ -11,6 +11,22 @@ export function BeforeAfterComparison({
 }: {
   photos: TreatmentPhoto[];
 }) {
+  const [urlMap, setUrlMap] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+
+  // 全写真のSigned URLを一括取得（N+1問題の解消）
+  useEffect(() => {
+    if (photos.length === 0) {
+      setLoading(false);
+      return;
+    }
+    const paths = photos.map((p) => p.storage_path);
+    getPhotoUrls(paths).then((map) => {
+      setUrlMap(map);
+      setLoading(false);
+    });
+  }, [photos]);
+
   const beforePhotos = photos.filter((p) => p.photo_type === "before");
   const afterPhotos = photos.filter((p) => p.photo_type === "after");
 
@@ -22,81 +38,82 @@ export function BeforeAfterComparison({
     <div className="space-y-4">
       <h3 className="font-bold">施術写真</h3>
 
-      {/* Side-by-side comparison when both exist */}
-      {hasBoth && (
-        <div className="space-y-3">
-          {beforePhotos.map((before, i) => {
-            const after = afterPhotos[i];
-            return (
-              <div key={before.id} className="grid grid-cols-2 gap-2">
-                <PhotoWithUrl photo={before} label="施術前" />
-                {after ? (
-                  <PhotoWithUrl photo={after} label="施術後" />
-                ) : (
-                  <div className="bg-background border border-border rounded-xl aspect-square flex items-center justify-center text-text-light text-sm">
-                    施術後の写真なし
+      {loading ? (
+        <div className="text-text-light text-sm py-4 text-center">
+          写真を読み込み中...
+        </div>
+      ) : (
+        <>
+          {/* 施術前後が両方ある場合: 横並び比較 */}
+          {hasBoth && (
+            <div className="space-y-3">
+              {beforePhotos.map((before, i) => {
+                const after = afterPhotos[i];
+                return (
+                  <div key={before.id} className="grid grid-cols-2 gap-2">
+                    <PhotoCard photo={before} url={urlMap.get(before.storage_path)} label="施術前" />
+                    {after ? (
+                      <PhotoCard photo={after} url={urlMap.get(after.storage_path)} label="施術後" />
+                    ) : (
+                      <div className="bg-background border border-border rounded-xl aspect-square flex items-center justify-center text-text-light text-sm">
+                        施術後の写真なし
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            );
-          })}
-          {/* Remaining after photos without matching before */}
-          {afterPhotos.length > beforePhotos.length && (
-            <div className="grid grid-cols-2 gap-2">
-              {afterPhotos.slice(beforePhotos.length).map((photo) => (
-                <div key={photo.id} className="col-start-2">
-                  <PhotoWithUrl photo={photo} label="施術後" />
+                );
+              })}
+              {/* 施術後のみ余りがある場合 */}
+              {afterPhotos.length > beforePhotos.length && (
+                <div className="grid grid-cols-2 gap-2">
+                  {afterPhotos.slice(beforePhotos.length).map((photo) => (
+                    <div key={photo.id} className="col-start-2">
+                      <PhotoCard photo={photo} url={urlMap.get(photo.storage_path)} label="施術後" />
+                    </div>
+                  ))}
                 </div>
-              ))}
+              )}
             </div>
           )}
-        </div>
-      )}
 
-      {/* Only before photos */}
-      {!hasBoth && beforePhotos.length > 0 && (
-        <div>
-          <p className="text-sm text-text-light mb-2">施術前</p>
-          <div className="grid grid-cols-2 gap-2">
-            {beforePhotos.map((photo) => (
-              <PhotoWithUrl key={photo.id} photo={photo} />
-            ))}
-          </div>
-        </div>
-      )}
+          {/* 施術前のみ */}
+          {!hasBoth && beforePhotos.length > 0 && (
+            <div>
+              <p className="text-sm text-text-light mb-2">施術前</p>
+              <div className="grid grid-cols-2 gap-2">
+                {beforePhotos.map((photo) => (
+                  <PhotoCard key={photo.id} photo={photo} url={urlMap.get(photo.storage_path)} />
+                ))}
+              </div>
+            </div>
+          )}
 
-      {/* Only after photos */}
-      {!hasBoth && afterPhotos.length > 0 && (
-        <div>
-          <p className="text-sm text-text-light mb-2">施術後</p>
-          <div className="grid grid-cols-2 gap-2">
-            {afterPhotos.map((photo) => (
-              <PhotoWithUrl key={photo.id} photo={photo} />
-            ))}
-          </div>
-        </div>
+          {/* 施術後のみ */}
+          {!hasBoth && afterPhotos.length > 0 && (
+            <div>
+              <p className="text-sm text-text-light mb-2">施術後</p>
+              <div className="grid grid-cols-2 gap-2">
+                {afterPhotos.map((photo) => (
+                  <PhotoCard key={photo.id} photo={photo} url={urlMap.get(photo.storage_path)} />
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );
 }
 
-function PhotoWithUrl({
+/** 個別の写真カード（URLはpropsで受け取り、自身ではfetchしない） */
+function PhotoCard({
   photo,
+  url,
   label,
 }: {
   photo: TreatmentPhoto;
+  url?: string;
   label?: string;
 }) {
-  const [url, setUrl] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    getPhotoUrl(photo.storage_path).then((signedUrl) => {
-      setUrl(signedUrl);
-      setLoading(false);
-    });
-  }, [photo.storage_path]);
-
   return (
     <div className="bg-background border border-border rounded-xl overflow-hidden">
       {label && (
@@ -104,15 +121,12 @@ function PhotoWithUrl({
           <span className="text-xs font-medium text-primary">{label}</span>
         </div>
       )}
-      {loading ? (
-        <div className="aspect-square flex items-center justify-center text-text-light text-sm">
-          読み込み中...
-        </div>
-      ) : url ? (
+      {url ? (
         /* eslint-disable-next-line @next/next/no-img-element */
         <img
           src={url}
           alt={label ?? "施術写真"}
+          loading="lazy"
           className="w-full aspect-square object-cover"
         />
       ) : (


### PR DESCRIPTION
## Summary
- アップロード前の画像圧縮: Canvas APIで最大1200pxにリサイズ + JPEG 85%品質（スマホ写真5-15MB → 約200-400KBに削減）
- Signed URL一括取得: `createSignedUrls`で写真N枚を1リクエストで取得（N+1問題解消）
- 写真の遅延読み込み: `loading="lazy"` を全写真に追加
- クエリバグ修正: カルテ詳細の `description`（存在しないカラム）→ `memo` に修正

## Test plan
- [ ] カルテ新規作成 → 写真添付 → 保存 → カルテ詳細で写真が表示されること
- [ ] 大きな写真（5MB以上）アップロード → ストレージ上のファイルサイズが大幅削減されていること
- [ ] 複数写真のカルテ詳細 → ネットワークタブでSigned URLリクエストが1回であること
- [ ] memoフィールドが写真に正しく表示されること
- [ ] `npx next build` エラーゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)