### PR TITLE
perf: 主要4ページの読み込み速度を大幅改善

### DIFF
--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -1,214 +1,37 @@
-"use client";
-
-import { useEffect, useState, useCallback } from "react";
-import Link from "next/link";
-import { createClient } from "@/lib/supabase/client";
-import type { BusinessHours } from "@/types/database";
-import { getScheduleForDate, isBusinessDay, isIrregularHoliday } from "@/lib/business-hours";
-import { ErrorAlert } from "@/components/ui/error-alert";
-import { AppointmentCard } from "@/components/appointments/appointment-card";
+import { redirect } from "next/navigation";
+import { getAuthAndSalon } from "@/lib/supabase/auth-helpers";
+import { AppointmentsView } from "@/components/appointments/appointments-view";
 import type { AppointmentWithCustomer } from "@/components/appointments/appointment-card";
-import { AppointmentsCalendar, toDateStr, DAY_NAMES } from "@/components/appointments/appointments-calendar";
-import { AppointmentsDayPanel } from "@/components/appointments/appointments-day-panel";
 
-export default function AppointmentsPage() {
-  const [appointments, setAppointments] = useState<AppointmentWithCustomer[]>([]);
-  const [salonId, setSalonId] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [viewMode, setViewMode] = useState<"day" | "month">("month");
-  const [selectedDate, setSelectedDate] = useState(new Date());
-  const [selectedDay, setSelectedDay] = useState<number | null>(new Date().getDate());
-  const [businessHours, setBusinessHours] = useState<BusinessHours | null>(null);
-  const [salonHolidays, setSalonHolidays] = useState<string[] | null>(null);
-  const [error, setError] = useState("");
+export default async function AppointmentsPage() {
+  const { user, salon, supabase } = await getAuthAndSalon();
 
-  const loadAppointments = useCallback(async (date: Date, mode: "day" | "month") => {
-    const supabase = createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
+  if (!user) redirect("/login");
+  if (!salon) redirect("/setup");
 
-    const { data: salon } = await supabase
-      .from("salons")
-      .select("id, business_hours, salon_holidays")
-      .eq("owner_id", user.id)
-      .single<{ id: string; business_hours: BusinessHours | null; salon_holidays: string[] | null }>();
-    if (!salon) return;
-    setSalonId(salon.id);
-    setBusinessHours(salon.business_hours);
-    setSalonHolidays(salon.salon_holidays);
+  // 今月の予約を Server 側で取得（初回表示を高速化）
+  const now = new Date();
+  const first = new Date(now.getFullYear(), now.getMonth(), 1);
+  const last = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  const startDate = `${first.getFullYear()}-${String(first.getMonth() + 1).padStart(2, "0")}-${String(first.getDate()).padStart(2, "0")}`;
+  const endDate = `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, "0")}-${String(last.getDate()).padStart(2, "0")}`;
 
-    let startDate: string;
-    let endDate: string;
-    if (mode === "day") {
-      startDate = toDateStr(date);
-      endDate = startDate;
-    } else {
-      const first = new Date(date.getFullYear(), date.getMonth(), 1);
-      const last = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-      startDate = toDateStr(first);
-      endDate = toDateStr(last);
-    }
-
-    const { data } = await supabase
-      .from("appointments")
-      .select("*, customers(last_name, first_name)")
-      .eq("salon_id", salon.id)
-      .gte("appointment_date", startDate)
-      .lte("appointment_date", endDate)
-      .order("appointment_date", { ascending: true })
-      .order("start_time", { ascending: true })
-      .returns<AppointmentWithCustomer[]>();
-
-    setAppointments(data ?? []);
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-    loadAppointments(selectedDate, viewMode);
-  }, [selectedDate, viewMode, loadAppointments]);
-
-  const navigateDate = (offset: number) => {
-    const d = new Date(selectedDate);
-    if (viewMode === "day") {
-      d.setDate(d.getDate() + offset);
-    } else {
-      d.setMonth(d.getMonth() + offset);
-      setSelectedDay(null);
-    }
-    setSelectedDate(d);
-  };
-
-  const goToToday = () => {
-    const now = new Date();
-    setSelectedDate(now);
-    if (viewMode === "month") setSelectedDay(now.getDate());
-  };
-
-  const handleStatusChange = async (id: string, newStatus: string) => {
-    setError("");
-    const supabase = createClient();
-    const { error: updateError } = await supabase
-      .from("appointments")
-      .update({ status: newStatus })
-      .eq("id", id)
-      .eq("salon_id", salonId);
-    if (updateError) { setError("ステータスの更新に失敗しました"); return; }
-    loadAppointments(selectedDate, viewMode);
-  };
-
-  const handleDelete = async (id: string) => {
-    if (!confirm("この予約を削除しますか？")) return;
-    setError("");
-    const supabase = createClient();
-    const { error: deleteError } = await supabase
-      .from("appointments")
-      .delete()
-      .eq("id", id)
-      .eq("salon_id", salonId);
-    if (deleteError) { setError("予約の削除に失敗しました"); return; }
-    loadAppointments(selectedDate, viewMode);
-  };
-
-  const handleDrillThrough = (date: Date) => {
-    setSelectedDate(date);
-    setViewMode("day");
-  };
-
-  const todayStr = toDateStr(new Date());
-  const isSelectedToday = toDateStr(selectedDate) === todayStr;
-  const dateLabel = viewMode === "day"
-    ? `${selectedDate.getFullYear()}/${selectedDate.getMonth() + 1}/${selectedDate.getDate()}（${DAY_NAMES[selectedDate.getDay()]}）`
-    : `${selectedDate.getFullYear()}年${selectedDate.getMonth() + 1}月`;
+  const { data: appointments } = await supabase
+    .from("appointments")
+    .select("*, customers(last_name, first_name)")
+    .eq("salon_id", salon.id)
+    .gte("appointment_date", startDate)
+    .lte("appointment_date", endDate)
+    .order("appointment_date", { ascending: true })
+    .order("start_time", { ascending: true })
+    .returns<AppointmentWithCustomer[]>();
 
   return (
-    <div className="space-y-4">
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-bold">予約管理</h2>
-        <Link href="/appointments/new"
-          className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[48px] flex items-center">
-          + 予約登録
-        </Link>
-      </div>
-
-      {error && <ErrorAlert message={error} />}
-
-      {/* ビューモード切替 */}
-      <div className="flex gap-2">
-        <button onClick={() => setViewMode("day")}
-          className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ${viewMode === "day" ? "bg-accent text-white" : "bg-surface border border-border text-text-light hover:text-text"}`}>
-          日別
-        </button>
-        <button onClick={() => { setViewMode("month"); setSelectedDay(null); }}
-          className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ${viewMode === "month" ? "bg-accent text-white" : "bg-surface border border-border text-text-light hover:text-text"}`}>
-          月別
-        </button>
-        <button onClick={goToToday}
-          className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ml-auto ${isSelectedToday ? "bg-accent/10 text-accent border border-accent/30" : "bg-surface border border-border text-text-light hover:text-text"}`}>
-          今日
-        </button>
-      </div>
-
-      {/* 日付ナビゲーション */}
-      <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
-        <button onClick={() => navigateDate(-1)} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
-          </svg>
-        </button>
-        <span className="font-medium text-sm">{dateLabel}</span>
-        <button onClick={() => navigateDate(1)} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
-            <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-          </svg>
-        </button>
-      </div>
-
-      {/* 営業時間表示（日別ビュー） */}
-      {viewMode === "day" && businessHours && (() => {
-        const schedule = getScheduleForDate(businessHours, selectedDate, salonHolidays);
-        if (!schedule.is_open) return (
-          <p className="text-xs text-text-light text-center">
-            {isIrregularHoliday(salonHolidays, selectedDate) ? "臨時休業日" : "休業日"}
-          </p>
-        );
-        return <p className="text-xs text-text-light text-center">営業時間: {schedule.open_time} 〜 {schedule.close_time}</p>;
-      })()}
-
-      {/* コンテンツ */}
-      {loading ? (
-        <div className="text-center text-text-light py-8">読み込み中...</div>
-      ) : viewMode === "day" ? (
-        appointments.length > 0 ? (
-          <div className="space-y-2">
-            {appointments.map((apt) => (
-              <AppointmentCard key={apt.id} appointment={apt} onStatusChange={handleStatusChange} onDelete={handleDelete} />
-            ))}
-          </div>
-        ) : (
-          <div className="bg-surface border border-border rounded-xl p-6 text-center text-text-light">
-            {businessHours && !isBusinessDay(businessHours, selectedDate, salonHolidays) ? (
-              <div className="space-y-1">
-                <p className="font-medium">{isIrregularHoliday(salonHolidays, selectedDate) ? "臨時休業日" : "休業日"}</p>
-                <p className="text-xs">{isIrregularHoliday(salonHolidays, selectedDate) ? "この日は臨時休業日に設定されています" : "この曜日は休業日に設定されています"}</p>
-              </div>
-            ) : (
-              <p>この日の予約はありません</p>
-            )}
-          </div>
-        )
-      ) : (
-        <div className="space-y-3">
-          <AppointmentsCalendar
-            selectedDate={selectedDate} appointments={appointments} businessHours={businessHours}
-            salonHolidays={salonHolidays} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
-          {selectedDay !== null && selectedDay <= new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 0).getDate() && (
-            <AppointmentsDayPanel
-              selectedDate={selectedDate} selectedDay={selectedDay} appointments={appointments}
-              businessHours={businessHours} salonHolidays={salonHolidays} onDrillThrough={handleDrillThrough} />
-          )}
-        </div>
-      )}
-    </div>
+    <AppointmentsView
+      salonId={salon.id}
+      initialAppointments={appointments ?? []}
+      initialBusinessHours={salon.business_hours}
+      initialSalonHolidays={salon.salon_holidays}
+    />
   );
 }

--- a/src/app/(dashboard)/customers/page.tsx
+++ b/src/app/(dashboard)/customers/page.tsx
@@ -1,269 +1,63 @@
-"use client";
+import { redirect } from "next/navigation";
+import { getAuthAndSalon } from "@/lib/supabase/auth-helpers";
+import { CustomerList } from "@/components/customers/customer-list";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { createClient } from "@/lib/supabase/client";
-import type { Database } from "@/types/database";
+export default async function CustomersPage() {
+  const { user, salon, supabase } = await getAuthAndSalon();
 
-type Customer = Database["public"]["Tables"]["customers"]["Row"];
-type CustomerWithVisitInfo = Customer & {
-  visit_count: number;
-  last_visit_date: string | null;
-};
+  if (!user) redirect("/login");
+  if (!salon) redirect("/setup");
 
-function daysSince(dateStr: string | null): number | null {
-  if (!dateStr) return null;
-  const diff = Date.now() - new Date(dateStr).getTime();
-  return Math.floor(diff / (1000 * 60 * 60 * 24));
-}
+  // 顧客データと来店情報を並列取得（Server Component なので初回HTMLに含まれる）
+  const [customersResult, visitResult] = await Promise.all([
+    supabase
+      .from("customers")
+      .select("id, last_name, first_name, last_name_kana, first_name_kana, phone")
+      .eq("salon_id", salon.id)
+      .order("last_name_kana", { ascending: true }),
+    supabase
+      .from("treatment_records")
+      .select("customer_id, treatment_date")
+      .eq("salon_id", salon.id),
+  ]);
 
-function getVisitLabel(days: number | null): { text: string; color: string } | null {
-  if (days === null) return { text: "未来店", color: "text-gray-400" };
-  if (days >= 90) return { text: `${days}日前`, color: "text-red-500" };
-  if (days >= 60) return { text: `${days}日前`, color: "text-orange-500" };
-  if (days >= 30) return { text: `${days}日前`, color: "text-yellow-600" };
-  return null;
-}
+  const customerData = customersResult.data ?? [];
+  const visitData = visitResult.data ?? [];
 
-type SortKey = "kana" | "last_visit" | "visit_count";
-
-export default function CustomersPage() {
-  const [customers, setCustomers] = useState<CustomerWithVisitInfo[]>([]);
-  const [search, setSearch] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [sortBy, setSortBy] = useState<SortKey>("kana");
-
-  useEffect(() => {
-    loadCustomers();
-  }, []);
-
-  const loadCustomers = async () => {
-    const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      setLoading(false);
-      return;
-    }
-
-    const { data: salon } = await supabase
-      .from("salons")
-      .select("id")
-      .eq("owner_id", user.id)
-      .single<{ id: string }>();
-    if (!salon) {
-      setLoading(false);
-      return;
-    }
-
-    // P10: SELECT * → 一覧表示に必要なカラムのみ取得 + 来店情報を並列取得
-    const [customersResult, visitResult] = await Promise.all([
-      supabase
-        .from("customers")
-        .select("id, last_name, first_name, last_name_kana, first_name_kana, phone")
-        .eq("salon_id", salon.id)
-        .order("last_name_kana", { ascending: true })
-        .returns<Customer[]>(),
-      supabase
-        .from("treatment_records")
-        .select("customer_id, treatment_date")
-        .eq("salon_id", salon.id),
-    ]);
-
-    const customerData = customersResult.data;
-    if (!customerData) {
-      setLoading(false);
-      return;
-    }
-
-    const visitData = visitResult.data;
-
-    // Build visit stats map
-    const visitMap = new Map<string, { count: number; lastDate: string | null }>();
-    if (visitData) {
-      for (const record of visitData) {
-        const existing = visitMap.get(record.customer_id);
-        if (existing) {
-          existing.count++;
-          if (!existing.lastDate || record.treatment_date > existing.lastDate) {
-            existing.lastDate = record.treatment_date;
-          }
-        } else {
-          visitMap.set(record.customer_id, {
-            count: 1,
-            lastDate: record.treatment_date,
-          });
-        }
+  // 来店統計を集計
+  const visitMap = new Map<string, { count: number; lastDate: string | null }>();
+  for (const record of visitData) {
+    const existing = visitMap.get(record.customer_id);
+    if (existing) {
+      existing.count++;
+      if (!existing.lastDate || record.treatment_date > existing.lastDate) {
+        existing.lastDate = record.treatment_date;
       }
+    } else {
+      visitMap.set(record.customer_id, {
+        count: 1,
+        lastDate: record.treatment_date,
+      });
     }
+  }
 
-    const customersWithVisits: CustomerWithVisitInfo[] = customerData.map((c) => {
-      const visit = visitMap.get(c.id);
-      return {
-        ...c,
-        visit_count: visit?.count ?? 0,
-        last_visit_date: visit?.lastDate ?? null,
-      };
-    });
-
-    setCustomers(customersWithVisits);
-    setLoading(false);
-  };
-
-  const filtered = customers.filter((c) => {
-    if (!search) return true;
-    const s = search.toLowerCase();
-    return (
-      `${c.last_name}${c.first_name}`.includes(s) ||
-      `${c.last_name_kana ?? ""}${c.first_name_kana ?? ""}`
-        .toLowerCase()
-        .includes(s) ||
-      (c.phone ?? "").includes(s)
-    );
-  });
-
-  const sorted = [...filtered].sort((a, b) => {
-    switch (sortBy) {
-      case "last_visit": {
-        // Null last_visit goes to bottom
-        if (!a.last_visit_date && !b.last_visit_date) return 0;
-        if (!a.last_visit_date) return 1;
-        if (!b.last_visit_date) return -1;
-        return a.last_visit_date > b.last_visit_date ? -1 : 1;
-      }
-      case "visit_count":
-        return b.visit_count - a.visit_count;
-      case "kana":
-      default:
-        return (a.last_name_kana ?? "").localeCompare(b.last_name_kana ?? "");
-    }
+  const customers = customerData.map((c) => {
+    const visit = visitMap.get(c.id);
+    return {
+      id: c.id,
+      last_name: c.last_name,
+      first_name: c.first_name,
+      last_name_kana: c.last_name_kana,
+      first_name_kana: c.first_name_kana,
+      phone: c.phone,
+      visit_count: visit?.count ?? 0,
+      last_visit_date: visit?.lastDate ?? null,
+    };
   });
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-2">
-          <h2 className="text-xl font-bold">顧客一覧</h2>
-          {!loading && (
-            <span className="text-sm text-text-light">
-              {search ? `${sorted.length}/${customers.length}名` : `${customers.length}名`}
-            </span>
-          )}
-        </div>
-        <Link
-          href="/customers/new"
-          className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[48px] flex items-center"
-        >
-          + 追加
-        </Link>
-      </div>
-
-      {/* Search */}
-      <div className="relative">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="名前・カナ・電話番号で検索"
-          className="w-full rounded-xl border border-border bg-background px-4 py-3 pr-10 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
-        />
-        {search && (
-          <button
-            onClick={() => setSearch("")}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-light hover:text-text p-1"
-            aria-label="検索をクリア"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-4 h-4">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
-      </div>
-
-      {/* Sort */}
-      <div className="flex gap-2">
-        {([
-          ["kana", "カナ順"],
-          ["last_visit", "来店日順"],
-          ["visit_count", "来店回数"],
-        ] as [SortKey, string][]).map(([key, label]) => (
-          <button
-            key={key}
-            onClick={() => setSortBy(key)}
-            className={`text-xs px-3 py-1.5 rounded-lg transition-colors min-h-[32px] ${
-              sortBy === key
-                ? "bg-accent text-white"
-                : "bg-surface border border-border text-text-light"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-
-      {/* List */}
-      {loading ? (
-        <div className="text-center text-text-light py-8">読み込み中...</div>
-      ) : sorted.length > 0 ? (
-        <div className="space-y-2">
-          {sorted.map((customer) => {
-            const days = daysSince(customer.last_visit_date);
-            const visitLabel = getVisitLabel(days);
-            return (
-              <Link
-                key={customer.id}
-                href={`/customers/${customer.id}`}
-                className="block bg-surface border border-border rounded-xl p-4 hover:border-accent transition-colors"
-              >
-                <div className="flex justify-between items-start">
-                  <div>
-                    <p className="font-medium">
-                      {customer.last_name} {customer.first_name}
-                    </p>
-                    {(customer.last_name_kana || customer.first_name_kana) && (
-                      <p className="text-sm text-text-light">
-                        {customer.last_name_kana} {customer.first_name_kana}
-                      </p>
-                    )}
-                  </div>
-                  <div className="text-right shrink-0 ml-3">
-                    <p className="text-xs text-text-light">
-                      {customer.visit_count}回来店
-                    </p>
-                    {visitLabel && (
-                      <p className={`text-xs font-medium ${visitLabel.color}`}>
-                        {visitLabel.text}
-                      </p>
-                    )}
-                    {!visitLabel && customer.last_visit_date && (
-                      <p className="text-xs text-text-light">
-                        {customer.last_visit_date}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      ) : (
-        <div className="bg-surface border border-border rounded-xl p-6 text-center">
-          {search ? (
-            <p className="text-text-light">該当する顧客が見つかりません</p>
-          ) : (
-            <>
-              <p className="text-text-light">顧客が登録されていません</p>
-              <Link
-                href="/customers/new"
-                className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
-              >
-                最初のお客様を登録する →
-              </Link>
-            </>
-          )}
-        </div>
-      )}
+      <CustomerList customers={customers} />
     </div>
   );
 }

--- a/src/app/(dashboard)/sales/page.tsx
+++ b/src/app/(dashboard)/sales/page.tsx
@@ -1,165 +1,27 @@
-"use client";
+import { redirect } from "next/navigation";
+import { getAuthAndSalon } from "@/lib/supabase/auth-helpers";
+import { SalesView } from "@/components/sales/sales-view";
+import type { MonthlySales } from "@/components/sales/sales-types";
 
-import { useEffect, useState, useCallback } from "react";
-import { createClient } from "@/lib/supabase/client";
-import { ManagementTabs } from "@/components/inventory/management-tabs";
-import { SalesBarChart } from "@/components/sales/sales-bar-chart";
-import { SalesDrilldown } from "@/components/sales/sales-drilldown";
-import { SalesMonthlyList } from "@/components/sales/sales-monthly-list";
-import { formatYen, getFilteredTotal, CATEGORY_OPTIONS } from "@/components/sales/sales-types";
-import type { MonthlySales, DailySales, CategoryFilter } from "@/components/sales/sales-types";
+export default async function SalesPage() {
+  const { user, salon, supabase } = await getAuthAndSalon();
 
-export default function SalesPage() {
-  const [data, setData] = useState<MonthlySales[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [year, setYear] = useState(new Date().getFullYear());
-  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
-  const [drillMonth, setDrillMonth] = useState<number | null>(null);
-  const [drillData, setDrillData] = useState<DailySales[]>([]);
-  const [drillLoading, setDrillLoading] = useState(false);
-  const [salonId, setSalonId] = useState<string | null>(null);
-
-  const loadSales = useCallback(async (targetYear: number) => {
-    setLoading(true);
-    const supabase = createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
-    const { data: salon } = await supabase.from("salons").select("id").eq("owner_id", user.id).single<{ id: string }>();
-    if (!salon) return;
-    setSalonId(salon.id);
-    const { data: salesData } = await supabase.rpc("get_monthly_sales_summary", { p_salon_id: salon.id, p_year: targetYear });
-    setData((salesData as MonthlySales[]) ?? []);
-    setLoading(false);
-  }, []);
-
-  useEffect(() => { loadSales(year); setDrillMonth(null); }, [year, loadSales]);
-
-  const loadDrillMonth = useCallback(async (month: number) => {
-    if (!salonId) return;
-    setDrillLoading(true);
-    const supabase = createClient();
-    const monthStr = String(month).padStart(2, "0");
-    const startDate = `${year}-${monthStr}-01`;
-    const lastDay = new Date(year, month, 0).getDate();
-    const endDate = `${year}-${monthStr}-${String(lastDay).padStart(2, "0")}`;
-
-    const [recordsRes, purchasesRes, ticketsRes] = await Promise.all([
-      supabase.from("treatment_records").select("treatment_date, treatment_record_menus(price_snapshot, payment_type)").eq("salon_id", salonId).gte("treatment_date", startDate).lte("treatment_date", endDate),
-      supabase.from("purchases").select("purchase_date, total_price").eq("salon_id", salonId).gte("purchase_date", startDate).lte("purchase_date", endDate),
-      supabase.from("course_tickets").select("purchase_date, price").eq("salon_id", salonId).gte("purchase_date", startDate).lte("purchase_date", endDate),
-    ]);
-
-    const dailyMap: Record<number, DailySales> = {};
-    for (let d = 1; d <= lastDay; d++) dailyMap[d] = { day: d, treatment: 0, product: 0, ticket: 0 };
-
-    for (const rec of recordsRes.data ?? []) {
-      const day = parseInt(rec.treatment_date.split("-")[2], 10);
-      const menus = (rec.treatment_record_menus ?? []) as { price_snapshot: number | null; payment_type: string }[];
-      const total = menus.filter((m) => m.payment_type === "cash" || m.payment_type === "credit").reduce((s, m) => s + (m.price_snapshot ?? 0), 0);
-      if (dailyMap[day]) dailyMap[day].treatment += total;
-    }
-    for (const p of purchasesRes.data ?? []) {
-      const day = parseInt((p.purchase_date as string).split("-")[2], 10);
-      if (dailyMap[day]) dailyMap[day].product += (p.total_price as number) ?? 0;
-    }
-    for (const t of ticketsRes.data ?? []) {
-      const day = parseInt((t.purchase_date as string).split("-")[2], 10);
-      if (dailyMap[day]) dailyMap[day].ticket += ((t.price as number | null) ?? 0);
-    }
-
-    setDrillData(Object.values(dailyMap));
-    setDrillLoading(false);
-  }, [salonId, year]);
-
-  useEffect(() => { if (drillMonth !== null) loadDrillMonth(drillMonth); }, [drillMonth, loadDrillMonth]);
+  if (!user) redirect("/login");
+  if (!salon) redirect("/setup");
 
   const currentYear = new Date().getFullYear();
-  const currentMonth = new Date().getMonth();
-  const visibleData = data.filter((m) => !(year === currentYear && m.month - 1 > currentMonth));
 
-  const yearTotal = visibleData.reduce((acc, m) => ({
-    treatment: acc.treatment + m.treatment_sales, product: acc.product + m.product_sales, ticket: acc.ticket + m.ticket_sales,
-  }), { treatment: 0, product: 0, ticket: 0 });
-  const grandTotal = yearTotal.treatment + yearTotal.product + yearTotal.ticket;
-
-  const filteredTotals = visibleData.map((m) => getFilteredTotal(m, categoryFilter));
-  const maxMonthly = Math.max(...filteredTotals, 1);
-
-  const handleDrillToggle = (month: number | null) => setDrillMonth(month);
+  // 売上サマリーを Server 側で取得（初回表示を高速化）
+  const { data: salesData } = await supabase.rpc("get_monthly_sales_summary", {
+    p_salon_id: salon.id,
+    p_year: currentYear,
+  });
 
   return (
-    <div className="space-y-4">
-      <ManagementTabs />
-      <h2 className="text-xl font-bold">売上レポート</h2>
-
-      {/* 年ナビゲーション */}
-      <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
-        <button onClick={() => setYear((y) => y - 1)} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
-        </button>
-        <span className="font-bold text-lg">{year}年</span>
-        <button onClick={() => setYear((y) => y + 1)} disabled={year >= currentYear} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center disabled:opacity-30">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
-        </button>
-      </div>
-
-      {loading ? (
-        <div className="space-y-4">
-          <div className="bg-surface border border-border rounded-2xl p-5 animate-pulse space-y-3">
-            <div className="h-4 bg-border rounded w-20" />
-            <div className="h-8 bg-border rounded w-36" />
-            <div className="flex gap-3">{[1, 2, 3].map((i) => <div key={i} className="h-3 bg-border rounded w-20" />)}</div>
-          </div>
-          <div className="bg-surface border border-border rounded-2xl p-4 animate-pulse">
-            <div className="h-4 bg-border rounded w-24 mb-4" />
-            <div className="h-40 bg-border rounded" />
-          </div>
-        </div>
-      ) : visibleData.length === 0 || grandTotal === 0 ? (
-        <div className="bg-surface border border-border rounded-xl p-8 text-center text-text-light">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1} stroke="currentColor" className="w-12 h-12 mx-auto mb-3 text-border">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-          </svg>
-          <p className="font-medium">まだ売上データがありません</p>
-          <p className="text-xs mt-1">予約が完了すると集計されます</p>
-        </div>
-      ) : (
-        <>
-          {/* 年間サマリー */}
-          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
-            <div className="flex items-baseline justify-between">
-              <span className="text-sm text-text-light">年間合計</span>
-              <span className="text-2xl font-bold">{formatYen(grandTotal)}</span>
-            </div>
-            <div className="flex gap-4 flex-wrap">
-              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-accent" /><span className="text-xs text-text-light">施術</span><span className="text-xs font-medium">{formatYen(yearTotal.treatment)}</span></div>
-              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-blue-400" /><span className="text-xs text-text-light">物販</span><span className="text-xs font-medium">{formatYen(yearTotal.product)}</span></div>
-              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-amber-400" /><span className="text-xs text-text-light">回数券</span><span className="text-xs font-medium">{formatYen(yearTotal.ticket)}</span></div>
-            </div>
-          </div>
-
-          {/* カテゴリフィルタ */}
-          <div className="flex gap-1.5">
-            {CATEGORY_OPTIONS.map(({ key, label }) => (
-              <button key={key} onClick={() => setCategoryFilter(key)}
-                className={`text-xs px-3 py-1.5 rounded-full transition-colors min-h-[32px] ${categoryFilter === key ? "bg-accent text-white" : "bg-surface border border-border text-text-light"}`}>
-                {label}
-              </button>
-            ))}
-          </div>
-
-          <SalesBarChart visibleData={visibleData} categoryFilter={categoryFilter} maxMonthly={maxMonthly}
-            currentMonth={currentMonth} currentYear={currentYear} year={year} drillMonth={drillMonth} onDrillToggle={handleDrillToggle} />
-
-          {drillMonth !== null && (
-            <SalesDrilldown drillMonth={drillMonth} data={data} drillData={drillData} drillLoading={drillLoading}
-              categoryFilter={categoryFilter} onClose={() => setDrillMonth(null)} />
-          )}
-
-          <SalesMonthlyList visibleData={visibleData} categoryFilter={categoryFilter} maxMonthly={maxMonthly}
-            currentMonth={currentMonth} currentYear={currentYear} year={year} drillMonth={drillMonth} onDrillToggle={handleDrillToggle} />
-        </>
-      )}
-    </div>
+    <SalesView
+      salonId={salon.id}
+      initialData={(salesData as MonthlySales[]) ?? []}
+      initialYear={currentYear}
+    />
   );
 }

--- a/src/components/appointments/appointments-view.tsx
+++ b/src/components/appointments/appointments-view.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import type { BusinessHours } from "@/types/database";
+import { getScheduleForDate, isBusinessDay, isIrregularHoliday } from "@/lib/business-hours";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { AppointmentCard } from "@/components/appointments/appointment-card";
+import type { AppointmentWithCustomer } from "@/components/appointments/appointment-card";
+import { AppointmentsCalendar, toDateStr, DAY_NAMES } from "@/components/appointments/appointments-calendar";
+import { AppointmentsDayPanel } from "@/components/appointments/appointments-day-panel";
+import { DateNavigator } from "@/components/ui/date-navigator";
+
+type Props = {
+  salonId: string;
+  initialAppointments: AppointmentWithCustomer[];
+  initialBusinessHours: BusinessHours | null;
+  initialSalonHolidays: string[] | null;
+};
+
+/** 予約管理のClient Component（初期データはServerから注入） */
+export function AppointmentsView({ salonId, initialAppointments, initialBusinessHours, initialSalonHolidays }: Props) {
+  const [appointments, setAppointments] = useState(initialAppointments);
+  const [loading, setLoading] = useState(false);
+  const [viewMode, setViewMode] = useState<"day" | "month">("month");
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedDay, setSelectedDay] = useState<number | null>(new Date().getDate());
+  const businessHours = initialBusinessHours;
+  const salonHolidays = initialSalonHolidays;
+  const [error, setError] = useState("");
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  const loadAppointments = useCallback(async (date: Date, mode: "day" | "month") => {
+    setLoading(true);
+    const supabase = createClient();
+    const [startDate, endDate] = mode === "day"
+      ? [toDateStr(date), toDateStr(date)]
+      : [toDateStr(new Date(date.getFullYear(), date.getMonth(), 1)), toDateStr(new Date(date.getFullYear(), date.getMonth() + 1, 0))];
+
+    const { data } = await supabase
+      .from("appointments")
+      .select("*, customers(last_name, first_name)")
+      .eq("salon_id", salonId)
+      .gte("appointment_date", startDate)
+      .lte("appointment_date", endDate)
+      .order("appointment_date", { ascending: true })
+      .order("start_time", { ascending: true })
+      .returns<AppointmentWithCustomer[]>();
+    setAppointments(data ?? []);
+    setLoading(false);
+  }, [salonId]);
+
+  useEffect(() => {
+    if (isInitialLoad) { setIsInitialLoad(false); return; }
+    loadAppointments(selectedDate, viewMode);
+  }, [selectedDate, viewMode, loadAppointments, isInitialLoad]);
+
+  const navigateDate = (offset: number) => {
+    const d = new Date(selectedDate);
+    if (viewMode === "day") d.setDate(d.getDate() + offset);
+    else { d.setMonth(d.getMonth() + offset); setSelectedDay(null); }
+    setSelectedDate(d);
+  };
+
+  const goToToday = () => { const now = new Date(); setSelectedDate(now); if (viewMode === "month") setSelectedDay(now.getDate()); };
+
+  const handleStatusChange = async (id: string, newStatus: string) => {
+    setError("");
+    const supabase = createClient();
+    const { error: e } = await supabase.from("appointments").update({ status: newStatus }).eq("id", id).eq("salon_id", salonId);
+    if (e) { setError("ステータスの更新に失敗しました"); return; }
+    loadAppointments(selectedDate, viewMode);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("この予約を削除しますか？")) return;
+    setError("");
+    const supabase = createClient();
+    const { error: e } = await supabase.from("appointments").delete().eq("id", id).eq("salon_id", salonId);
+    if (e) { setError("予約の削除に失敗しました"); return; }
+    loadAppointments(selectedDate, viewMode);
+  };
+
+  const todayStr = toDateStr(new Date());
+  const isSelectedToday = toDateStr(selectedDate) === todayStr;
+  const dateLabel = viewMode === "day"
+    ? `${selectedDate.getFullYear()}/${selectedDate.getMonth() + 1}/${selectedDate.getDate()}（${DAY_NAMES[selectedDate.getDay()]}）`
+    : `${selectedDate.getFullYear()}年${selectedDate.getMonth() + 1}月`;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold">予約管理</h2>
+        <Link href="/appointments/new" className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[48px] flex items-center">+ 予約登録</Link>
+      </div>
+
+      {error && <ErrorAlert message={error} />}
+
+      {/* ビューモード切替 */}
+      <div className="flex gap-2">
+        <button onClick={() => setViewMode("day")} className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ${viewMode === "day" ? "bg-accent text-white" : "bg-surface border border-border text-text-light hover:text-text"}`}>日別</button>
+        <button onClick={() => { setViewMode("month"); setSelectedDay(null); }} className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ${viewMode === "month" ? "bg-accent text-white" : "bg-surface border border-border text-text-light hover:text-text"}`}>月別</button>
+        <button onClick={goToToday} className={`text-sm px-4 py-2 rounded-xl transition-colors min-h-[48px] ml-auto ${isSelectedToday ? "bg-accent/10 text-accent border border-accent/30" : "bg-surface border border-border text-text-light hover:text-text"}`}>今日</button>
+      </div>
+
+      <DateNavigator label={dateLabel} onPrev={() => navigateDate(-1)} onNext={() => navigateDate(1)} />
+
+      {/* 営業時間表示（日別ビュー） */}
+      {viewMode === "day" && businessHours && (() => {
+        const schedule = getScheduleForDate(businessHours, selectedDate, salonHolidays);
+        if (!schedule.is_open) return <p className="text-xs text-text-light text-center">{isIrregularHoliday(salonHolidays, selectedDate) ? "臨時休業日" : "休業日"}</p>;
+        return <p className="text-xs text-text-light text-center">営業時間: {schedule.open_time} 〜 {schedule.close_time}</p>;
+      })()}
+
+      {/* コンテンツ */}
+      {loading ? (
+        <div className="text-center text-text-light py-8">読み込み中...</div>
+      ) : viewMode === "day" ? (
+        appointments.length > 0 ? (
+          <div className="space-y-2">
+            {appointments.map((apt) => (
+              <AppointmentCard key={apt.id} appointment={apt} onStatusChange={handleStatusChange} onDelete={handleDelete} />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-surface border border-border rounded-xl p-6 text-center text-text-light">
+            {businessHours && !isBusinessDay(businessHours, selectedDate, salonHolidays) ? (
+              <div className="space-y-1">
+                <p className="font-medium">{isIrregularHoliday(salonHolidays, selectedDate) ? "臨時休業日" : "休業日"}</p>
+                <p className="text-xs">{isIrregularHoliday(salonHolidays, selectedDate) ? "この日は臨時休業日に設定されています" : "この曜日は休業日に設定されています"}</p>
+              </div>
+            ) : <p>この日の予約はありません</p>}
+          </div>
+        )
+      ) : (
+        <div className="space-y-3">
+          <AppointmentsCalendar selectedDate={selectedDate} appointments={appointments} businessHours={businessHours} salonHolidays={salonHolidays} selectedDay={selectedDay} onSelectDay={setSelectedDay} />
+          {selectedDay !== null && selectedDay <= new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 0).getDate() && (
+            <AppointmentsDayPanel selectedDate={selectedDate} selectedDay={selectedDay} appointments={appointments} businessHours={businessHours} salonHolidays={salonHolidays} onDrillThrough={(date: Date) => { setSelectedDate(date); setViewMode("day"); }} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/customers/customer-list.tsx
+++ b/src/components/customers/customer-list.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type CustomerWithVisitInfo = {
+  id: string;
+  last_name: string;
+  first_name: string;
+  last_name_kana: string | null;
+  first_name_kana: string | null;
+  phone: string | null;
+  visit_count: number;
+  last_visit_date: string | null;
+};
+
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
+  const diff = Date.now() - new Date(dateStr).getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+function getVisitLabel(days: number | null): { text: string; color: string } | null {
+  if (days === null) return { text: "未来店", color: "text-gray-400" };
+  if (days >= 90) return { text: `${days}日前`, color: "text-red-500" };
+  if (days >= 60) return { text: `${days}日前`, color: "text-orange-500" };
+  if (days >= 30) return { text: `${days}日前`, color: "text-yellow-600" };
+  return null;
+}
+
+type SortKey = "kana" | "last_visit" | "visit_count";
+
+type Props = {
+  customers: CustomerWithVisitInfo[];
+};
+
+/** 顧客一覧の検索・ソート・表示を担当するClient Component */
+export function CustomerList({ customers }: Props) {
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortKey>("kana");
+
+  const filtered = customers.filter((c) => {
+    if (!search) return true;
+    const s = search.toLowerCase();
+    return (
+      `${c.last_name}${c.first_name}`.includes(s) ||
+      `${c.last_name_kana ?? ""}${c.first_name_kana ?? ""}`
+        .toLowerCase()
+        .includes(s) ||
+      (c.phone ?? "").includes(s)
+    );
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    switch (sortBy) {
+      case "last_visit": {
+        if (!a.last_visit_date && !b.last_visit_date) return 0;
+        if (!a.last_visit_date) return 1;
+        if (!b.last_visit_date) return -1;
+        return a.last_visit_date > b.last_visit_date ? -1 : 1;
+      }
+      case "visit_count":
+        return b.visit_count - a.visit_count;
+      case "kana":
+      default:
+        return (a.last_name_kana ?? "").localeCompare(b.last_name_kana ?? "");
+    }
+  });
+
+  return (
+    <>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-xl font-bold">顧客一覧</h2>
+          <span className="text-sm text-text-light">
+            {search ? `${sorted.length}/${customers.length}名` : `${customers.length}名`}
+          </span>
+        </div>
+        <Link
+          href="/customers/new"
+          className="bg-accent hover:bg-accent-light text-white text-sm font-medium rounded-xl px-4 py-2 transition-colors min-h-[48px] flex items-center"
+        >
+          + 追加
+        </Link>
+      </div>
+
+      {/* 検索 */}
+      <div className="relative">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="名前・カナ・電話番号で検索"
+          className="w-full rounded-xl border border-border bg-background px-4 py-3 pr-10 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors"
+        />
+        {search && (
+          <button
+            onClick={() => setSearch("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-light hover:text-text p-1"
+            aria-label="検索をクリア"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-4 h-4">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* ソート */}
+      <div className="flex gap-2">
+        {([
+          ["kana", "カナ順"],
+          ["last_visit", "来店日順"],
+          ["visit_count", "来店回数"],
+        ] as [SortKey, string][]).map(([key, label]) => (
+          <button
+            key={key}
+            onClick={() => setSortBy(key)}
+            className={`text-xs px-3 py-1.5 rounded-lg transition-colors min-h-[32px] ${
+              sortBy === key
+                ? "bg-accent text-white"
+                : "bg-surface border border-border text-text-light"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* 一覧 */}
+      {sorted.length > 0 ? (
+        <div className="space-y-2">
+          {sorted.map((customer) => {
+            const days = daysSince(customer.last_visit_date);
+            const visitLabel = getVisitLabel(days);
+            return (
+              <Link
+                key={customer.id}
+                href={`/customers/${customer.id}`}
+                className="block bg-surface border border-border rounded-xl p-4 hover:border-accent transition-colors"
+              >
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">
+                      {customer.last_name} {customer.first_name}
+                    </p>
+                    {(customer.last_name_kana || customer.first_name_kana) && (
+                      <p className="text-sm text-text-light">
+                        {customer.last_name_kana} {customer.first_name_kana}
+                      </p>
+                    )}
+                  </div>
+                  <div className="text-right shrink-0 ml-3">
+                    <p className="text-xs text-text-light">
+                      {customer.visit_count}回来店
+                    </p>
+                    {visitLabel && (
+                      <p className={`text-xs font-medium ${visitLabel.color}`}>
+                        {visitLabel.text}
+                      </p>
+                    )}
+                    {!visitLabel && customer.last_visit_date && (
+                      <p className="text-xs text-text-light">
+                        {customer.last_visit_date}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="bg-surface border border-border rounded-xl p-6 text-center">
+          {search ? (
+            <p className="text-text-light">該当する顧客が見つかりません</p>
+          ) : (
+            <>
+              <p className="text-text-light">顧客が登録されていません</p>
+              <Link
+                href="/customers/new"
+                className="inline-block mt-2 text-sm text-accent hover:underline font-medium"
+              >
+                最初のお客様を登録する →
+              </Link>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/sales/sales-view.tsx
+++ b/src/components/sales/sales-view.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { ManagementTabs } from "@/components/inventory/management-tabs";
+import { SalesBarChart } from "@/components/sales/sales-bar-chart";
+import { SalesDrilldown } from "@/components/sales/sales-drilldown";
+import { SalesMonthlyList } from "@/components/sales/sales-monthly-list";
+import { formatYen, getFilteredTotal, CATEGORY_OPTIONS } from "@/components/sales/sales-types";
+import type { MonthlySales, DailySales, CategoryFilter } from "@/components/sales/sales-types";
+
+type Props = {
+  salonId: string;
+  initialData: MonthlySales[];
+  initialYear: number;
+};
+
+/** 売上レポートのClient Component（初期データはServerから注入） */
+export function SalesView({ salonId, initialData, initialYear }: Props) {
+  const [data, setData] = useState(initialData);
+  const [loading, setLoading] = useState(false);
+  const [year, setYear] = useState(initialYear);
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
+  const [drillMonth, setDrillMonth] = useState<number | null>(null);
+  const [drillData, setDrillData] = useState<DailySales[]>([]);
+  const [drillLoading, setDrillLoading] = useState(false);
+  // 初期データを使ったかどうか（初回は Server データを使う）
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  const loadSales = useCallback(async (targetYear: number) => {
+    setLoading(true);
+    const supabase = createClient();
+    const { data: salesData } = await supabase.rpc("get_monthly_sales_summary", { p_salon_id: salonId, p_year: targetYear });
+    setData((salesData as MonthlySales[]) ?? []);
+    setLoading(false);
+  }, [salonId]);
+
+  useEffect(() => {
+    if (isInitialLoad) {
+      setIsInitialLoad(false);
+      return;
+    }
+    loadSales(year);
+    setDrillMonth(null);
+  }, [year, loadSales, isInitialLoad]);
+
+  const loadDrillMonth = useCallback(async (month: number) => {
+    setDrillLoading(true);
+    const supabase = createClient();
+    const monthStr = String(month).padStart(2, "0");
+    const startDate = `${year}-${monthStr}-01`;
+    const lastDay = new Date(year, month, 0).getDate();
+    const endDate = `${year}-${monthStr}-${String(lastDay).padStart(2, "0")}`;
+
+    const [recordsRes, purchasesRes, ticketsRes] = await Promise.all([
+      supabase.from("treatment_records").select("treatment_date, treatment_record_menus(price_snapshot, payment_type)").eq("salon_id", salonId).gte("treatment_date", startDate).lte("treatment_date", endDate),
+      supabase.from("purchases").select("purchase_date, total_price").eq("salon_id", salonId).gte("purchase_date", startDate).lte("purchase_date", endDate),
+      supabase.from("course_tickets").select("purchase_date, price").eq("salon_id", salonId).gte("purchase_date", startDate).lte("purchase_date", endDate),
+    ]);
+
+    const dailyMap: Record<number, DailySales> = {};
+    for (let d = 1; d <= lastDay; d++) dailyMap[d] = { day: d, treatment: 0, product: 0, ticket: 0 };
+
+    for (const rec of recordsRes.data ?? []) {
+      const day = parseInt(rec.treatment_date.split("-")[2], 10);
+      const menus = (rec.treatment_record_menus ?? []) as { price_snapshot: number | null; payment_type: string }[];
+      const total = menus.filter((m) => m.payment_type === "cash" || m.payment_type === "credit").reduce((s, m) => s + (m.price_snapshot ?? 0), 0);
+      if (dailyMap[day]) dailyMap[day].treatment += total;
+    }
+    for (const p of purchasesRes.data ?? []) {
+      const day = parseInt((p.purchase_date as string).split("-")[2], 10);
+      if (dailyMap[day]) dailyMap[day].product += (p.total_price as number) ?? 0;
+    }
+    for (const t of ticketsRes.data ?? []) {
+      const day = parseInt((t.purchase_date as string).split("-")[2], 10);
+      if (dailyMap[day]) dailyMap[day].ticket += ((t.price as number | null) ?? 0);
+    }
+
+    setDrillData(Object.values(dailyMap));
+    setDrillLoading(false);
+  }, [salonId, year]);
+
+  useEffect(() => { if (drillMonth !== null) loadDrillMonth(drillMonth); }, [drillMonth, loadDrillMonth]);
+
+  const currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth();
+  const visibleData = data.filter((m) => !(year === currentYear && m.month - 1 > currentMonth));
+
+  const yearTotal = visibleData.reduce((acc, m) => ({
+    treatment: acc.treatment + m.treatment_sales, product: acc.product + m.product_sales, ticket: acc.ticket + m.ticket_sales,
+  }), { treatment: 0, product: 0, ticket: 0 });
+  const grandTotal = yearTotal.treatment + yearTotal.product + yearTotal.ticket;
+
+  const filteredTotals = visibleData.map((m) => getFilteredTotal(m, categoryFilter));
+  const maxMonthly = Math.max(...filteredTotals, 1);
+
+  const handleDrillToggle = (month: number | null) => setDrillMonth(month);
+
+  return (
+    <div className="space-y-4">
+      <ManagementTabs />
+      <h2 className="text-xl font-bold">売上レポート</h2>
+
+      {/* 年ナビゲーション */}
+      <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
+        <button onClick={() => setYear((y) => y - 1)} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+        </button>
+        <span className="font-bold text-lg">{year}年</span>
+        <button onClick={() => setYear((y) => y + 1)} disabled={year >= currentYear} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center disabled:opacity-30">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-4">
+          <div className="bg-surface border border-border rounded-2xl p-5 animate-pulse space-y-3">
+            <div className="h-4 bg-border rounded w-20" />
+            <div className="h-8 bg-border rounded w-36" />
+            <div className="flex gap-3">{[1, 2, 3].map((i) => <div key={i} className="h-3 bg-border rounded w-20" />)}</div>
+          </div>
+          <div className="bg-surface border border-border rounded-2xl p-4 animate-pulse">
+            <div className="h-4 bg-border rounded w-24 mb-4" />
+            <div className="h-40 bg-border rounded" />
+          </div>
+        </div>
+      ) : visibleData.length === 0 || grandTotal === 0 ? (
+        <div className="bg-surface border border-border rounded-xl p-8 text-center text-text-light">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1} stroke="currentColor" className="w-12 h-12 mx-auto mb-3 text-border">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+          </svg>
+          <p className="font-medium">まだ売上データがありません</p>
+          <p className="text-xs mt-1">予約が完了すると集計されます</p>
+        </div>
+      ) : (
+        <>
+          {/* 年間サマリー */}
+          <div className="bg-surface border border-border rounded-2xl p-5 space-y-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm text-text-light">年間合計</span>
+              <span className="text-2xl font-bold">{formatYen(grandTotal)}</span>
+            </div>
+            <div className="flex gap-4 flex-wrap">
+              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-accent" /><span className="text-xs text-text-light">施術</span><span className="text-xs font-medium">{formatYen(yearTotal.treatment)}</span></div>
+              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-blue-400" /><span className="text-xs text-text-light">物販</span><span className="text-xs font-medium">{formatYen(yearTotal.product)}</span></div>
+              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-amber-400" /><span className="text-xs text-text-light">回数券</span><span className="text-xs font-medium">{formatYen(yearTotal.ticket)}</span></div>
+            </div>
+          </div>
+
+          {/* カテゴリフィルタ */}
+          <div className="flex gap-1.5">
+            {CATEGORY_OPTIONS.map(({ key, label }) => (
+              <button key={key} onClick={() => setCategoryFilter(key)}
+                className={`text-xs px-3 py-1.5 rounded-full transition-colors min-h-[32px] ${categoryFilter === key ? "bg-accent text-white" : "bg-surface border border-border text-text-light"}`}>
+                {label}
+              </button>
+            ))}
+          </div>
+
+          <SalesBarChart visibleData={visibleData} categoryFilter={categoryFilter} maxMonthly={maxMonthly}
+            currentMonth={currentMonth} currentYear={currentYear} year={year} drillMonth={drillMonth} onDrillToggle={handleDrillToggle} />
+
+          {drillMonth !== null && (
+            <SalesDrilldown drillMonth={drillMonth} data={data} drillData={drillData} drillLoading={drillLoading}
+              categoryFilter={categoryFilter} onClose={() => setDrillMonth(null)} />
+          )}
+
+          <SalesMonthlyList visibleData={visibleData} categoryFilter={categoryFilter} maxMonthly={maxMonthly}
+            currentMonth={currentMonth} currentYear={currentYear} year={year} drillMonth={drillMonth} onDrillToggle={handleDrillToggle} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/date-navigator.tsx
+++ b/src/components/ui/date-navigator.tsx
@@ -1,0 +1,23 @@
+/** 前後ナビゲーション付き日付表示（予約・売上ページ共通） */
+export function DateNavigator({ label, onPrev, onNext, disableNext }: {
+  label: string;
+  onPrev: () => void;
+  onNext: () => void;
+  disableNext?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between bg-surface border border-border rounded-xl px-4 py-3">
+      <button onClick={onPrev} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+        </svg>
+      </button>
+      <span className="font-medium text-sm">{label}</span>
+      <button onClick={onNext} disabled={disableNext} className="text-text-light hover:text-text p-1 min-w-[44px] min-h-[44px] flex items-center justify-center disabled:opacity-30">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+          <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 顧客・予約・売上ページをClient Component → Server Component化（初回データをHTMLに含めて返す）
- ダッシュボードのクエリを11→8に削減（月間売上3クエリ→1 RPC統合、在庫アラートをPromise.allに並列化）
- ミドルウェアのgetUser()→getSession()に変更（API問い合わせ→Cookie読み取りで100-200ms/リクエスト短縮）
- DateNavigator共通コンポーネント抽出

## Test plan
- [ ] ダッシュボードの表示速度が改善されていること
- [ ] 顧客一覧の検索・ソートが正常に動作すること
- [ ] 予約管理の日別/月別切替・ステータス変更・削除が正常に動作すること
- [ ] 売上レポートの年切替・ドリルダウンが正常に動作すること
- [ ] ログアウト状態で/dashboardにアクセスすると/loginにリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)