### PR TITLE
feat: 予約キャンセル機能・リマインドメール・受付時間制限を追加

### DIFF
--- a/src/app/(booking)/book/cancel/[token]/page.tsx
+++ b/src/app/(booking)/book/cancel/[token]/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+type AppointmentInfo = {
+  appointmentDate: string;
+  startTime: string;
+  status: string;
+  menuName: string | null;
+  salonName: string;
+  bookingSlug: string | null;
+};
+
+const DAY_NAMES = ["日", "月", "火", "水", "木", "金", "土"];
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(Date.UTC(year, month - 1, day));
+  const dow = DAY_NAMES[d.getUTCDay()];
+  return `${month}月${day}日（${dow}）`;
+}
+
+export default function CancelPage() {
+  const { token } = useParams<{ token: string }>();
+  const [info, setInfo] = useState<AppointmentInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [cancelling, setCancelling] = useState(false);
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/booking/cancel?token=${token}`);
+      if (!res.ok) {
+        setError("予約が見つかりません");
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setInfo(data);
+      setLoading(false);
+    };
+    load();
+  }, [token]);
+
+  const handleCancel = async () => {
+    setCancelling(true);
+    setError("");
+
+    const res = await fetch("/api/booking/cancel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || "キャンセルに失敗しました");
+      setCancelling(false);
+      return;
+    }
+
+    setDone(true);
+    setCancelling(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center py-12">
+        <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin mx-auto" />
+      </div>
+    );
+  }
+
+  // キャンセル完了画面
+  if (done && info) {
+    return (
+      <div className="text-center py-12 space-y-6">
+        <div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center mx-auto">
+          <svg className="w-10 h-10 text-red-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold">予約をキャンセルしました</h1>
+          <p className="text-text-light text-sm leading-relaxed">
+            キャンセル確認メールをお送りしました。
+          </p>
+        </div>
+        <div className="bg-surface border border-border rounded-xl p-4 text-left space-y-1">
+          <p className="text-sm text-text-light">
+            <span className="font-medium text-text">日時:</span> {formatDate(info.appointmentDate)} {info.startTime.slice(0, 5)}〜
+          </p>
+          {info.menuName && (
+            <p className="text-sm text-text-light">
+              <span className="font-medium text-text">メニュー:</span> {info.menuName}
+            </p>
+          )}
+        </div>
+        {info.bookingSlug && (
+          <Link
+            href={`/book/${info.bookingSlug}`}
+            className="inline-block text-sm text-accent hover:underline font-medium"
+          >
+            再度予約する
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  // エラー画面（予約が見つからない等）
+  if (error && !info) {
+    return (
+      <div className="text-center py-12 space-y-4">
+        <div className="w-20 h-20 bg-gray-100 rounded-full flex items-center justify-center mx-auto">
+          <svg className="w-10 h-10 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+          </svg>
+        </div>
+        <h1 className="text-xl font-bold">{error}</h1>
+        <p className="text-text-light text-sm">
+          URLが無効か、すでにキャンセル済みの可能性があります。
+        </p>
+      </div>
+    );
+  }
+
+  // すでにキャンセル済みの場合
+  if (info?.status === "cancelled") {
+    return (
+      <div className="text-center py-12 space-y-4">
+        <div className="w-20 h-20 bg-gray-100 rounded-full flex items-center justify-center mx-auto">
+          <svg className="w-10 h-10 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </div>
+        <h1 className="text-xl font-bold">この予約はすでにキャンセル済みです</h1>
+        {info.bookingSlug && (
+          <Link
+            href={`/book/${info.bookingSlug}`}
+            className="inline-block text-sm text-accent hover:underline font-medium"
+          >
+            再度予約する
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  // 完了済みの場合
+  if (info?.status === "completed") {
+    return (
+      <div className="text-center py-12 space-y-4">
+        <h1 className="text-xl font-bold">この予約は完了しています</h1>
+        <p className="text-text-light text-sm">完了した予約はキャンセルできません。</p>
+      </div>
+    );
+  }
+
+  // キャンセル確認画面
+  return (
+    <div className="py-8 space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">予約のキャンセル</h1>
+        <p className="text-text-light text-sm">
+          以下の予約をキャンセルしますか？
+        </p>
+      </div>
+
+      {info && (
+        <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
+          <p className="text-xs text-text-light font-bold">予約内容</p>
+          <p className="text-sm">
+            <span className="font-medium">サロン:</span> {info.salonName}
+          </p>
+          <p className="text-sm">
+            <span className="font-medium">日時:</span> {formatDate(info.appointmentDate)} {info.startTime.slice(0, 5)}〜
+          </p>
+          {info.menuName && (
+            <p className="text-sm">
+              <span className="font-medium">メニュー:</span> {info.menuName}
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-3">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <button
+          onClick={handleCancel}
+          disabled={cancelling}
+          className="w-full bg-red-500 hover:bg-red-600 text-white font-bold rounded-xl py-3 transition-colors disabled:opacity-50 min-h-[48px]"
+        >
+          {cancelling ? "キャンセル中..." : "予約をキャンセルする"}
+        </button>
+
+        {info?.bookingSlug && (
+          <Link
+            href={`/book/${info.bookingSlug}`}
+            className="block w-full text-center text-sm text-text-light py-2 min-h-[48px] leading-[48px]"
+          >
+            戻る
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/booking-rules/page.tsx
+++ b/src/app/(dashboard)/settings/booking-rules/page.tsx
@@ -25,6 +25,17 @@ const CONCURRENT_OPTIONS = [
   { value: 5, label: "5" },
 ] as const;
 
+const ADVANCE_HOURS_OPTIONS = [
+  { value: 0, label: "制限なし" },
+  { value: 1, label: "1時間前まで" },
+  { value: 2, label: "2時間前まで" },
+  { value: 3, label: "3時間前まで" },
+  { value: 6, label: "6時間前まで" },
+  { value: 12, label: "12時間前まで" },
+  { value: 24, label: "24時間前（前日）まで" },
+  { value: 48, label: "48時間前（2日前）まで" },
+] as const;
+
 const DEFAULT_SETTINGS: BookingSettings = {
   same_day_enabled: true,
   lead_time_minutes: 0,
@@ -137,6 +148,25 @@ export default function BookingRulesPage() {
             </select>
           </div>
         )}
+
+        {/* 受付締切時間 */}
+        <div className="space-y-2">
+          <h3 className="font-bold text-sm">受付締切時間</h3>
+          <p className="text-xs text-text-light">
+            予約の何時間前まで受け付けるか（当日以外も適用）
+          </p>
+          <select
+            value={settings.min_advance_hours ?? 0}
+            onChange={(e) =>
+              setSettings({ ...settings, min_advance_hours: Number(e.target.value) })
+            }
+            className="w-full rounded-xl border border-border bg-background px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors min-h-[48px]"
+          >
+            {ADVANCE_HOURS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
 
         {/* 同時予約数の上限 */}
         <div className="space-y-2">

--- a/src/app/api/booking/[slug]/submit/route.ts
+++ b/src/app/api/booking/[slug]/submit/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { calculateAvailableSlots } from "@/lib/booking-slots";
 import { timeToMinutes, minutesToTime } from "@/lib/business-hours";
@@ -180,6 +181,7 @@ export async function POST(
   }
 
   // --- 予約作成 ---
+  const cancelToken = randomUUID();
   const menuNameSnapshot = menus.map((m) => m.name).join("、");
   const { data: appointment, error: aptError } = await admin
     .from("appointments")
@@ -195,6 +197,7 @@ export async function POST(
       memo: memo?.trim() || null,
       status: "scheduled",
       staff_id: null,
+      cancel_token: cancelToken,
     })
     .select("id")
     .single();
@@ -229,6 +232,7 @@ export async function POST(
 
   // --- 通知送信（fire-and-forget: 失敗しても予約は成功扱い） ---
   const customerName = `${last_name.trim()} ${first_name.trim()}`;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `https://${request.headers.get("host")}`;
   sendWebBookingNotifications({
     salonId: salon.id,
     salonName: salon.name,
@@ -245,6 +249,7 @@ export async function POST(
     customerPhone: normalizedPhone,
     isNewCustomer,
     memo: memo?.trim() || null,
+    cancelUrl: `${baseUrl}/book/cancel/${cancelToken}`,
   }).catch(() => {});
 
   return NextResponse.json({ success: true, appointmentId: appointment.id });

--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -1,0 +1,215 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getResendClient, getFromAddress } from "@/lib/email/client";
+import {
+  buildCustomerCancelConfirmationEmail,
+  buildOwnerCancelNotificationEmail,
+} from "@/lib/email/templates";
+
+// POST: 予約キャンセル（公開API — cancel_tokenで認証）
+export async function POST(request: Request) {
+  let body: { token: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "不正なリクエストです" }, { status: 400 });
+  }
+
+  const { token } = body;
+  if (!token || typeof token !== "string") {
+    return NextResponse.json({ error: "トークンが不正です" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+
+  // キャンセルトークンで予約を検索
+  const { data: appointment, error: aptError } = await admin
+    .from("appointments")
+    .select("id, salon_id, customer_id, appointment_date, start_time, status, menu_name_snapshot")
+    .eq("cancel_token", token)
+    .single();
+
+  if (aptError || !appointment) {
+    return NextResponse.json({ error: "予約が見つかりません" }, { status: 404 });
+  }
+
+  // すでにキャンセル済み
+  if (appointment.status === "cancelled") {
+    return NextResponse.json({ error: "この予約はすでにキャンセルされています" }, { status: 400 });
+  }
+
+  // 完了済みの予約はキャンセル不可
+  if (appointment.status === "completed") {
+    return NextResponse.json({ error: "完了した予約はキャンセルできません" }, { status: 400 });
+  }
+
+  // 過去の予約はキャンセル不可
+  const now = new Date();
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  if (appointment.appointment_date < todayStr) {
+    return NextResponse.json({ error: "過去の予約はキャンセルできません" }, { status: 400 });
+  }
+
+  // ステータスをキャンセルに更新
+  const { error: updateError } = await admin
+    .from("appointments")
+    .update({ status: "cancelled" })
+    .eq("id", appointment.id)
+    .eq("salon_id", appointment.salon_id);
+
+  if (updateError) {
+    console.error("予約キャンセルエラー:", updateError);
+    return NextResponse.json({ error: "キャンセルに失敗しました" }, { status: 500 });
+  }
+
+  // 通知メール送信（fire-and-forget）
+  sendCancelNotifications({
+    salonId: appointment.salon_id,
+    customerId: appointment.customer_id,
+    appointmentDate: appointment.appointment_date,
+    startTime: appointment.start_time,
+    menuNameSnapshot: appointment.menu_name_snapshot,
+  }).catch(() => {});
+
+  return NextResponse.json({ success: true });
+}
+
+// GET: キャンセルトークンで予約情報を取得（キャンセル確認画面用）
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+
+  if (!token) {
+    return NextResponse.json({ error: "トークンが不正です" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+
+  const { data: appointment, error } = await admin
+    .from("appointments")
+    .select("id, salon_id, appointment_date, start_time, status, menu_name_snapshot")
+    .eq("cancel_token", token)
+    .single();
+
+  if (error || !appointment) {
+    return NextResponse.json({ error: "予約が見つかりません" }, { status: 404 });
+  }
+
+  // サロン名を取得
+  const { data: salon } = await admin
+    .from("salons")
+    .select("name, booking_slug")
+    .eq("id", appointment.salon_id)
+    .single();
+
+  return NextResponse.json({
+    appointmentDate: appointment.appointment_date,
+    startTime: appointment.start_time,
+    status: appointment.status,
+    menuName: appointment.menu_name_snapshot,
+    salonName: salon?.name ?? "",
+    bookingSlug: salon?.booking_slug ?? null,
+  });
+}
+
+// キャンセル通知メール送信
+async function sendCancelNotifications(params: {
+  salonId: string;
+  customerId: string;
+  appointmentDate: string;
+  startTime: string;
+  menuNameSnapshot: string | null;
+}): Promise<void> {
+  const admin = createAdminClient();
+
+  // 顧客情報取得
+  const { data: customer } = await admin
+    .from("customers")
+    .select("last_name, first_name, email")
+    .eq("id", params.customerId)
+    .eq("salon_id", params.salonId)
+    .single();
+
+  if (!customer) return;
+
+  // サロン情報取得
+  const { data: salon } = await admin
+    .from("salons")
+    .select("name, phone, owner_id, booking_slug")
+    .eq("id", params.salonId)
+    .single();
+
+  if (!salon) return;
+
+  // メニュー名の取得（appointment_menusから）
+  const menuNames = params.menuNameSnapshot
+    ? params.menuNameSnapshot.split("、")
+    : [];
+
+  const customerName = `${customer.last_name} ${customer.first_name}`;
+
+  const results = await Promise.allSettled([
+    // 顧客へキャンセル確認メール
+    (async () => {
+      if (!customer.email) return;
+      const resend = getResendClient();
+      if (!resend) return;
+
+      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://www.salonkarte.com";
+      const bookingUrl = salon.booking_slug ? `${baseUrl}/book/${salon.booking_slug}` : undefined;
+
+      const { subject, html } = buildCustomerCancelConfirmationEmail({
+        customerName,
+        appointmentDate: params.appointmentDate,
+        startTime: params.startTime,
+        menuNames,
+        salonName: salon.name,
+        salonPhone: salon.phone,
+        bookingUrl,
+      });
+
+      const { error } = await resend.emails.send({
+        from: getFromAddress(),
+        to: customer.email,
+        subject,
+        html,
+      });
+      if (error) throw new Error(`キャンセル確認メール送信失敗: ${error.message}`);
+    })(),
+
+    // オーナーへキャンセル通知メール
+    (async () => {
+      const resend = getResendClient();
+      if (!resend) return;
+
+      const { data: { user } } = await admin.auth.admin.getUserById(salon.owner_id);
+      if (!user?.email) return;
+
+      const { subject, html } = buildOwnerCancelNotificationEmail({
+        customerName,
+        appointmentDate: params.appointmentDate,
+        startTime: params.startTime,
+        menuNames,
+        salonName: salon.name,
+      });
+
+      const { error } = await resend.emails.send({
+        from: getFromAddress(),
+        to: user.email,
+        subject,
+        html,
+      });
+      if (error) throw new Error(`オーナーキャンセル通知メール送信失敗: ${error.message}`);
+    })(),
+  ]);
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.error("キャンセル通知エラー:", result.reason);
+      Sentry.captureException(result.reason, {
+        tags: { feature: "booking-cancel-notification" },
+      });
+    }
+  }
+}

--- a/src/app/api/cron/line-reminders/route.ts
+++ b/src/app/api/cron/line-reminders/route.ts
@@ -4,8 +4,11 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { decrypt } from "@/lib/line/crypto";
 import { sendPushMessage } from "@/lib/line/api";
 import { buildReminderMessage } from "@/lib/line/messages";
+import { getResendClient, getFromAddress } from "@/lib/email/client";
+import { buildCustomerReminderEmail } from "@/lib/email/templates";
 
 // POST: 前日リマインド（Vercel Cron Job: 毎日 12:00 UTC = 21:00 JST）
+// LINE + メール の両チャネルで送信
 export async function POST(request: Request) {
   // CRON_SECRET検証（未設定時はリクエストを拒否）
   const cronSecret = process.env.CRON_SECRET;
@@ -27,124 +30,159 @@ export async function POST(request: Request) {
   tomorrow.setDate(tomorrow.getDate() + 1);
   const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
 
-  // リマインドが有効なサロンを取得
-  const { data: configs } = await adminClient
-    .from("salon_line_configs")
-    .select("salon_id, channel_access_token_encrypted")
-    .eq("is_active", true)
-    .eq("reminder_enabled", true);
+  // 全サロンの明日の予約を取得（scheduled のみ）
+  const { data: appointments } = await adminClient
+    .from("appointments")
+    .select("id, salon_id, customer_id, appointment_date, start_time, staff_id, cancel_token")
+    .eq("appointment_date", tomorrowStr)
+    .eq("status", "scheduled");
 
-  if (!configs || configs.length === 0) {
-    return NextResponse.json({ sent: 0, failed: 0, message: "対象サロンなし" });
+  if (!appointments || appointments.length === 0) {
+    return NextResponse.json({ line: { sent: 0, failed: 0 }, email: { sent: 0, failed: 0 }, date: tomorrowStr });
   }
 
-  let totalSent = 0;
-  let totalFailed = 0;
+  // サロンIDリストを取得してサロン情報を一括取得
+  const salonIds = [...new Set(appointments.map((a) => a.salon_id))];
+  const { data: salons } = await adminClient
+    .from("salons")
+    .select("id, name, phone, booking_slug")
+    .in("id", salonIds);
 
-  for (const config of configs) {
-    // サロン名を取得
-    const { data: salon } = await adminClient
-      .from("salons")
-      .select("name")
-      .eq("id", config.salon_id)
-      .single();
+  const salonMap = new Map((salons ?? []).map((s) => [s.id, s]));
 
+  // LINE設定を一括取得
+  const { data: lineConfigs } = await adminClient
+    .from("salon_line_configs")
+    .select("salon_id, channel_access_token_encrypted, is_active, reminder_enabled")
+    .in("salon_id", salonIds);
+
+  const lineConfigMap = new Map((lineConfigs ?? []).map((c) => [c.salon_id, c]));
+
+  const stats = { line: { sent: 0, failed: 0 }, email: { sent: 0, failed: 0 } };
+
+  for (const apt of appointments) {
+    const salon = salonMap.get(apt.salon_id);
     if (!salon) continue;
 
-    // 明日の予約を取得（scheduled のみ）
-    const { data: appointments } = await adminClient
-      .from("appointments")
-      .select("id, customer_id, appointment_date, start_time, staff_id")
-      .eq("salon_id", config.salon_id)
-      .eq("appointment_date", tomorrowStr)
-      .eq("status", "scheduled");
+    // 顧客情報を取得
+    const { data: customer } = await adminClient
+      .from("customers")
+      .select("last_name, first_name, email")
+      .eq("id", apt.customer_id)
+      .eq("salon_id", apt.salon_id)
+      .single();
 
-    if (!appointments || appointments.length === 0) continue;
+    if (!customer) continue;
 
-    const accessToken = decrypt(config.channel_access_token_encrypted);
+    const customerName = `${customer.last_name}${customer.first_name}`;
 
-    for (const apt of appointments) {
-      // 顧客名を取得
-      const { data: customer } = await adminClient
-        .from("customers")
-        .select("last_name, first_name")
-        .eq("id", apt.customer_id)
-        .eq("salon_id", config.salon_id)
-        .single();
+    // メニュー名を取得
+    const { data: menus } = await adminClient
+      .from("appointment_menus")
+      .select("menu_name_snapshot")
+      .eq("appointment_id", apt.id)
+      .order("sort_order", { ascending: true });
 
-      if (!customer) continue;
+    const menuNames = (menus ?? []).map((m) => m.menu_name_snapshot);
 
-      // LINE紐付けを確認
+    // --- LINE リマインド ---
+    const lineConfig = lineConfigMap.get(apt.salon_id);
+    if (lineConfig?.is_active && lineConfig?.reminder_enabled) {
       const { data: lineLink } = await adminClient
         .from("customer_line_links")
         .select("id, line_user_id, is_following")
         .eq("customer_id", apt.customer_id)
-        .eq("salon_id", config.salon_id)
+        .eq("salon_id", apt.salon_id)
         .single();
 
-      if (!lineLink || !lineLink.is_following) continue;
+      if (lineLink?.is_following) {
+        // スタッフ名を取得
+        let staffName: string | null = null;
+        if (apt.staff_id) {
+          const { data: staffData } = await adminClient
+            .from("staff")
+            .select("name")
+            .eq("id", apt.staff_id)
+            .eq("salon_id", apt.salon_id)
+            .single();
+          staffName = staffData?.name ?? null;
+        }
 
-      // メニュー名を取得
-      const { data: menus } = await adminClient
-        .from("appointment_menus")
-        .select("menu_name_snapshot")
-        .eq("appointment_id", apt.id)
-        .order("sort_order", { ascending: true });
+        const message = buildReminderMessage({
+          customerName,
+          appointmentDate: apt.appointment_date,
+          startTime: apt.start_time,
+          menuNames,
+          salonName: salon.name,
+          staffName,
+        });
 
-      const menuNames = (menus ?? []).map((m) => m.menu_name_snapshot);
+        try {
+          const accessToken = decrypt(lineConfig.channel_access_token_encrypted);
+          await sendPushMessage(accessToken, lineLink.line_user_id, [message]);
 
-      // スタッフ名を取得
-      let staffName: string | null = null;
-      if (apt.staff_id) {
-        const { data: staffData } = await adminClient
-          .from("staff")
-          .select("name")
-          .eq("id", apt.staff_id)
-          .eq("salon_id", config.salon_id)
-          .single();
-        staffName = staffData?.name ?? null;
+          await adminClient.from("line_message_logs").insert({
+            salon_id: apt.salon_id,
+            customer_line_link_id: lineLink.id,
+            message_type: "reminder",
+            status: "sent",
+            related_appointment_id: apt.id,
+            sent_at: new Date().toISOString(),
+          });
+          stats.line.sent++;
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : "送信失敗";
+          console.error(`LINE リマインド送信エラー (salon: ${apt.salon_id}):`, errorMessage);
+          Sentry.captureException(err, { tags: { feature: "line-reminder" }, extra: { salon_id: apt.salon_id } });
+
+          await adminClient.from("line_message_logs").insert({
+            salon_id: apt.salon_id,
+            customer_line_link_id: lineLink.id,
+            message_type: "reminder",
+            status: "failed",
+            error_message: errorMessage,
+            related_appointment_id: apt.id,
+          });
+          stats.line.failed++;
+        }
       }
+    }
 
-      const message = buildReminderMessage({
-        customerName: `${customer.last_name}${customer.first_name}`,
-        appointmentDate: apt.appointment_date,
-        startTime: apt.start_time,
-        menuNames,
-        salonName: salon.name,
-        staffName,
-      });
+    // --- メール リマインド ---
+    if (customer.email) {
+      const resend = getResendClient();
+      if (resend) {
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://www.salonkarte.com";
+        const cancelUrl = apt.cancel_token ? `${baseUrl}/book/cancel/${apt.cancel_token}` : undefined;
 
-      try {
-        await sendPushMessage(accessToken, lineLink.line_user_id, [message]);
-
-        await adminClient.from("line_message_logs").insert({
-          salon_id: config.salon_id,
-          customer_line_link_id: lineLink.id,
-          message_type: "reminder",
-          status: "sent",
-          related_appointment_id: apt.id,
-          sent_at: new Date().toISOString(),
+        const { subject, html } = buildCustomerReminderEmail({
+          customerName,
+          appointmentDate: apt.appointment_date,
+          startTime: apt.start_time,
+          menuNames,
+          salonName: salon.name,
+          salonPhone: salon.phone,
+          cancelUrl,
         });
 
-        totalSent++;
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "送信失敗";
-        console.error(`LINE リマインド送信エラー (salon: ${config.salon_id}):`, errorMessage);
-        Sentry.captureException(err, { tags: { feature: "line-reminder" }, extra: { salon_id: config.salon_id } });
-
-        await adminClient.from("line_message_logs").insert({
-          salon_id: config.salon_id,
-          customer_line_link_id: lineLink.id,
-          message_type: "reminder",
-          status: "failed",
-          error_message: errorMessage,
-          related_appointment_id: apt.id,
-        });
-
-        totalFailed++;
+        try {
+          const { error } = await resend.emails.send({
+            from: getFromAddress(),
+            to: customer.email,
+            subject,
+            html,
+          });
+          if (error) throw new Error(error.message);
+          stats.email.sent++;
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : "送信失敗";
+          console.error(`メール リマインド送信エラー (salon: ${apt.salon_id}):`, errorMessage);
+          Sentry.captureException(err, { tags: { feature: "email-reminder" }, extra: { salon_id: apt.salon_id } });
+          stats.email.failed++;
+        }
       }
     }
   }
 
-  return NextResponse.json({ sent: totalSent, failed: totalFailed, date: tomorrowStr });
+  return NextResponse.json({ ...stats, date: tomorrowStr });
 }

--- a/src/lib/booking-slots.ts
+++ b/src/lib/booking-slots.ts
@@ -55,6 +55,32 @@ export function calculateAvailableSlots({
 
   const maxConcurrent = bookingSettings?.max_concurrent_appointments ?? 1;
 
+  // min_advance_hours: 予約受付締切（X時間前まで受付可能）
+  // 例: min_advance_hours=2 → 予約の2時間前を過ぎたスロットはブロック
+  const minAdvanceHours = bookingSettings?.min_advance_hours ?? 0;
+  let advanceThresholdMin = -1;
+  if (minAdvanceHours > 0) {
+    const now = new Date();
+    const nowMs = now.getTime();
+    const [y, mo, d] = date.split("-").map(Number);
+    // 対象日のスロット時刻をJSTとして、現在時刻 + X時間 より前のスロットをブロック
+    // nowMs + advanceHours の時刻を対象日の分に変換
+    const slotDateStart = new Date(y, mo - 1, d, 0, 0, 0).getTime();
+    const thresholdMs = nowMs + minAdvanceHours * 60 * 60 * 1000;
+    // 閾値が対象日の範囲内の場合のみ適用
+    if (thresholdMs > slotDateStart) {
+      const thresholdDate = new Date(thresholdMs);
+      // 対象日と同じ日の場合のみスロット単位でブロック
+      const thresholdDateStr = `${thresholdDate.getFullYear()}-${String(thresholdDate.getMonth() + 1).padStart(2, "0")}-${String(thresholdDate.getDate()).padStart(2, "0")}`;
+      if (thresholdDateStr === date) {
+        advanceThresholdMin = thresholdDate.getHours() * 60 + thresholdDate.getMinutes();
+      } else if (thresholdMs > slotDateStart + 24 * 60 * 60 * 1000) {
+        // 閾値が対象日を完全に過ぎている場合、全スロット不可
+        return [];
+      }
+    }
+  }
+
   // リードタイム制限: 当日のみ、現在時刻+lead_time_minutes より前のスロットをブロック
   const leadMin = bookingSettings?.lead_time_minutes ?? 0;
   let leadTimeThreshold = -1;
@@ -89,8 +115,10 @@ export function calculateAvailableSlots({
     // 基本チェック: 同時予約上限に達しているか
     const isOccupied = countOverlapping(m) >= maxConcurrent;
 
-    // リードタイム制限
-    const isBeforeLeadTime = leadTimeThreshold > 0 && m < leadTimeThreshold;
+    // リードタイム制限（当日の lead_time_minutes + 全日の min_advance_hours）
+    const isBeforeLeadTime =
+      (leadTimeThreshold > 0 && m < leadTimeThreshold) ||
+      (advanceThresholdMin > 0 && m < advanceThresholdMin);
 
     // 施術時間が閉店までに収まるか + 途中に埋まった枠がないか
     let canFit = true;

--- a/src/lib/booking/notifications.ts
+++ b/src/lib/booking/notifications.ts
@@ -25,6 +25,7 @@ type WebBookingNotificationParams = {
   customerPhone: string;
   isNewCustomer: boolean;
   memo?: string | null;
+  cancelUrl?: string;
 };
 
 // Web予約完了後の通知を一括送信（fire-and-forget）
@@ -66,6 +67,7 @@ async function sendCustomerEmail(
     totalDuration: params.totalDuration,
     salonName: params.salonName,
     salonPhone: params.salonPhone,
+    cancelUrl: params.cancelUrl,
   });
 
   const { error } = await resend.emails.send({

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -32,6 +32,19 @@ ${body}
 </html>`;
 }
 
+// 予約内容ブロック（各テンプレートで共通利用）
+function bookingDetailsBlock(date: string, time: string, menus: string, duration?: number): string {
+  const durationText = duration ? `（${duration}分）` : "";
+  return `
+  <table width="100%" style="background:#f9f7f5;border-radius:12px;padding:16px;" cellpadding="0" cellspacing="0">
+  <tr><td style="padding:16px;">
+    <p style="margin:0 0 12px;font-size:12px;color:#888;font-weight:bold;">予約内容</p>
+    <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>日時:</strong> ${date} ${time}〜${durationText}</p>
+    <p style="margin:0;font-size:14px;color:#333;"><strong>メニュー:</strong> ${menus}</p>
+  </td></tr>
+  </table>`;
+}
+
 type BookingInfo = {
   customerName: string;
   appointmentDate: string;
@@ -40,6 +53,7 @@ type BookingInfo = {
   totalDuration: number;
   salonName: string;
   salonPhone?: string | null;
+  cancelUrl?: string;
 };
 
 // 顧客向け: 予約確認メール
@@ -51,9 +65,16 @@ export function buildCustomerConfirmationEmail(info: BookingInfo): {
   const time = formatTime(info.startTime);
   const menus = info.menuNames.join("、");
 
-  const contactNote = info.salonPhone
-    ? `キャンセル・変更はサロンへ直接ご連絡ください。<br>電話番号: ${info.salonPhone}`
-    : "キャンセル・変更はサロンへ直接ご連絡ください。";
+  const cancelSection = info.cancelUrl
+    ? `<div style="margin:24px 0;text-align:center;">
+        <a href="${info.cancelUrl}" style="display:inline-block;background:#f5f5f5;color:#666;font-size:13px;padding:10px 24px;border-radius:8px;text-decoration:none;border:1px solid #ddd;">予約をキャンセルする</a>
+      </div>
+      <div style="padding:0 0 8px;"><p style="margin:0;font-size:11px;color:#999;text-align:center;">変更の場合はキャンセル後に再度ご予約ください</p></div>`
+    : `<div style="margin:24px 0;padding:16px;background:#fff8f0;border-radius:12px;border:1px solid #f0e6d8;">
+        <p style="margin:0;font-size:13px;color:#666;line-height:1.6;">
+          ${info.salonPhone ? `キャンセル・変更はサロンへ直接ご連絡ください。<br>電話番号: ${info.salonPhone}` : "キャンセル・変更はサロンへ直接ご連絡ください。"}
+        </p>
+      </div>`;
 
   const body = `
 <tr><td style="padding:32px 24px 0;text-align:center;">
@@ -64,18 +85,8 @@ export function buildCustomerConfirmationEmail(info: BookingInfo): {
   <p style="margin:0 0 24px;font-size:14px;color:#333;line-height:1.6;">
     ご予約ありがとうございます。<br>以下の内容で予約を受け付けました。
   </p>
-  <table width="100%" style="background:#f9f7f5;border-radius:12px;padding:16px;" cellpadding="0" cellspacing="0">
-  <tr><td style="padding:16px;">
-    <p style="margin:0 0 12px;font-size:12px;color:#888;font-weight:bold;">予約内容</p>
-    <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>日時:</strong> ${date} ${time}〜（${info.totalDuration}分）</p>
-    <p style="margin:0;font-size:14px;color:#333;"><strong>メニュー:</strong> ${menus}</p>
-  </td></tr>
-  </table>
-  <div style="margin:24px 0;padding:16px;background:#fff8f0;border-radius:12px;border:1px solid #f0e6d8;">
-    <p style="margin:0;font-size:13px;color:#666;line-height:1.6;">
-      ${contactNote}
-    </p>
-  </div>
+  ${bookingDetailsBlock(date, time, menus, info.totalDuration)}
+  ${cancelSection}
   <p style="margin:0;font-size:14px;color:#333;">ご来店をお待ちしております。</p>
   <p style="margin:8px 0 0;font-size:14px;color:#333;font-weight:bold;">${info.salonName}</p>
 </td></tr>`;
@@ -145,6 +156,147 @@ export function buildOwnerNotificationEmail(info: OwnerNotificationInfo): {
 
   return {
     subject: `【Web予約】${info.customerName}様（${date} ${time}）`,
+    html: wrapHtml(body),
+  };
+}
+
+type OwnerCancelNotificationInfo = {
+  customerName: string;
+  appointmentDate: string;
+  startTime: string;
+  menuNames: string[];
+  salonName: string;
+};
+
+// オーナー向け: 予約キャンセル通知メール
+export function buildOwnerCancelNotificationEmail(info: OwnerCancelNotificationInfo): {
+  subject: string;
+  html: string;
+} {
+  const date = formatDate(info.appointmentDate);
+  const time = formatTime(info.startTime);
+  const menus = info.menuNames.join("、");
+
+  const body = `
+<tr><td style="padding:32px 24px 0;text-align:center;">
+  <h1 style="margin:0;font-size:20px;color:#c62828;">予約がキャンセルされました</h1>
+</td></tr>
+<tr><td style="padding:24px;">
+  <p style="margin:0 0 16px;font-size:14px;color:#333;">
+    お客様がWeb予約をキャンセルしました。
+  </p>
+  <table width="100%" style="background:#fef2f2;border-radius:12px;" cellpadding="0" cellspacing="0">
+  <tr><td style="padding:16px;">
+    <p style="margin:0 0 12px;font-size:12px;color:#888;font-weight:bold;">キャンセル内容</p>
+    <p style="margin:0 0 8px;font-size:16px;color:#333;font-weight:bold;">${info.customerName}様</p>
+    <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>日時:</strong> ${date} ${time}〜</p>
+    <p style="margin:0;font-size:14px;color:#333;"><strong>メニュー:</strong> ${menus}</p>
+  </td></tr>
+  </table>
+  <p style="margin:24px 0 0;font-size:13px;color:#888;text-align:center;">
+    サロンカルテのダッシュボードで詳細を確認できます
+  </p>
+</td></tr>`;
+
+  return {
+    subject: `【キャンセル】${info.customerName}様（${date} ${time}）`,
+    html: wrapHtml(body),
+  };
+}
+
+type CustomerCancelConfirmationInfo = {
+  customerName: string;
+  appointmentDate: string;
+  startTime: string;
+  menuNames: string[];
+  salonName: string;
+  salonPhone?: string | null;
+  bookingUrl?: string;
+};
+
+// 顧客向け: キャンセル完了メール
+export function buildCustomerCancelConfirmationEmail(info: CustomerCancelConfirmationInfo): {
+  subject: string;
+  html: string;
+} {
+  const date = formatDate(info.appointmentDate);
+  const time = formatTime(info.startTime);
+  const menus = info.menuNames.join("、");
+
+  const rebookSection = info.bookingUrl
+    ? `<div style="margin:24px 0;text-align:center;">
+        <a href="${info.bookingUrl}" style="display:inline-block;background:#c4956a;color:#ffffff;font-size:14px;font-weight:bold;padding:12px 32px;border-radius:12px;text-decoration:none;">再度予約する</a>
+      </div>`
+    : "";
+
+  const body = `
+<tr><td style="padding:32px 24px 0;text-align:center;">
+  <h1 style="margin:0;font-size:20px;color:#333;">予約をキャンセルしました</h1>
+</td></tr>
+<tr><td style="padding:24px;">
+  <p style="margin:0 0 16px;font-size:14px;color:#333;">${info.customerName}様</p>
+  <p style="margin:0 0 24px;font-size:14px;color:#333;line-height:1.6;">
+    以下の予約をキャンセルいたしました。
+  </p>
+  <table width="100%" style="background:#f9f7f5;border-radius:12px;padding:16px;" cellpadding="0" cellspacing="0">
+  <tr><td style="padding:16px;">
+    <p style="margin:0 0 12px;font-size:12px;color:#888;font-weight:bold;">キャンセル済みの予約</p>
+    <p style="margin:0 0 8px;font-size:14px;color:#333;"><strong>日時:</strong> ${date} ${time}〜</p>
+    <p style="margin:0;font-size:14px;color:#333;"><strong>メニュー:</strong> ${menus}</p>
+  </td></tr>
+  </table>
+  ${rebookSection}
+  <p style="margin:16px 0 0;font-size:14px;color:#333;font-weight:bold;">${info.salonName}</p>
+</td></tr>`;
+
+  return {
+    subject: `【${info.salonName}】予約をキャンセルしました`,
+    html: wrapHtml(body),
+  };
+}
+
+type ReminderEmailInfo = {
+  customerName: string;
+  appointmentDate: string;
+  startTime: string;
+  menuNames: string[];
+  salonName: string;
+  salonPhone?: string | null;
+  cancelUrl?: string;
+};
+
+// 顧客向け: 予約リマインドメール（前日送信）
+export function buildCustomerReminderEmail(info: ReminderEmailInfo): {
+  subject: string;
+  html: string;
+} {
+  const date = formatDate(info.appointmentDate);
+  const time = formatTime(info.startTime);
+  const menus = info.menuNames.join("、");
+
+  const cancelSection = info.cancelUrl
+    ? `<div style="margin:16px 0;text-align:center;">
+        <a href="${info.cancelUrl}" style="font-size:12px;color:#999;text-decoration:underline;">キャンセルはこちら</a>
+      </div>`
+    : "";
+
+  const body = `
+<tr><td style="padding:32px 24px 0;text-align:center;">
+  <h1 style="margin:0;font-size:20px;color:#333;">明日のご予約のお知らせ</h1>
+</td></tr>
+<tr><td style="padding:24px;">
+  <p style="margin:0 0 16px;font-size:14px;color:#333;">${info.customerName}様</p>
+  <p style="margin:0 0 24px;font-size:14px;color:#333;line-height:1.6;">
+    明日のご予約をお知らせいたします。
+  </p>
+  ${bookingDetailsBlock(date, time, menus)}
+  ${cancelSection}
+  <p style="margin:16px 0 0;font-size:14px;color:#333;">ご来店をお待ちしております。</p>
+  <p style="margin:8px 0 0;font-size:14px;color:#333;font-weight:bold;">${info.salonName}</p>
+</td></tr>`;
+
+  return {
+    subject: `【${info.salonName}】明日のご予約のお知らせ`,
     html: wrapHtml(body),
   };
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -21,6 +21,7 @@ export type BookingSettings = {
   same_day_enabled: boolean;
   lead_time_minutes: number; // 0 = 制限なし / 30 / 60 / 120 / 180
   max_concurrent_appointments: number; // 同時予約上限 1〜5, デフォルト1
+  min_advance_hours?: number; // 予約受付締切（X時間前まで）。0 = 制限なし
 };
 
 export type Database = {
@@ -337,6 +338,7 @@ export type Database = {
           memo: string | null;
           treatment_record_id: string | null;
           staff_id: string | null;
+          cancel_token: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -354,6 +356,7 @@ export type Database = {
           memo?: string | null;
           treatment_record_id?: string | null;
           staff_id?: string | null;
+          cancel_token?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -371,6 +374,7 @@ export type Database = {
           memo?: string | null;
           treatment_record_id?: string | null;
           staff_id?: string | null;
+          cancel_token?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/supabase/migrations/00053_appointment_cancel_token.sql
+++ b/supabase/migrations/00053_appointment_cancel_token.sql
@@ -1,0 +1,10 @@
+-- 予約キャンセルトークン: 顧客がメールリンクからキャンセルできるようにする
+-- Web予約時にUUIDを生成し、メール内のキャンセルリンクに埋め込む
+
+ALTER TABLE appointments
+  ADD COLUMN cancel_token UUID DEFAULT NULL;
+
+-- キャンセルリンクからの高速検索用インデックス
+CREATE UNIQUE INDEX idx_appointments_cancel_token
+  ON appointments (cancel_token)
+  WHERE cancel_token IS NOT NULL;


### PR DESCRIPTION
- 顧客側キャンセル機能: cancel_tokenベースのキャンセルAPI・ページ・メール通知
- 予約確認メールにキャンセルリンクを追加
- 前日リマインドメール送信（既存LINEリマインドcronに統合）
- 受付時間制限（min_advance_hours）の設定UI・スロット計算を追加
- DBマイグレーション: appointments.cancel_tokenカラム追加

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01MjbY7fCVJ9BakE12H7WVLQ