### PR TITLE
fix: Web予約送信APIでhour_overridesを考慮するよう修正

### DIFF
--- a/src/app/api/booking/[slug]/submit/route.ts
+++ b/src/app/api/booking/[slug]/submit/route.ts
@@ -73,7 +73,7 @@ export async function POST(
   // --- サロン検索 ---
   const { data: salon, error: salonError } = await admin
     .from("salons")
-    .select("id, name, phone, owner_id, business_hours, salon_holidays, booking_settings, booking_enabled")
+    .select("id, name, phone, owner_id, business_hours, salon_holidays, hour_overrides, booking_settings, booking_enabled")
     .eq("booking_slug", slug)
     .single();
 
@@ -128,6 +128,7 @@ export async function POST(
   const slots = calculateAvailableSlots({
     businessHours: salon.business_hours,
     salonHolidays: salon.salon_holidays,
+    hourOverrides: salon.hour_overrides,
     bookingSettings: salon.booking_settings,
     date,
     existingAppointments: existingApts ?? [],


### PR DESCRIPTION
submit/route.tsのサロン情報SELECTにhour_overridesを追加し、
calculateAvailableSlotsに渡すことで、特定日の営業時間変更が
予約送信時の空き枠再検証にも反映されるようにした。

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01MjbY7fCVJ9BakE12H7WVLQ