### PR TITLE
feat: LPにプログラマティックなアプリモックアップを実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -234,6 +234,16 @@ input, select, textarea {
   animation: cta-pulse 2.5s ease-in-out infinite;
 }
 
+/* LP: ショーケース画面切替アニメーション */
+@keyframes screen-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-screen-fade-in {
+  animation: screen-fade-in 0.35s ease-out;
+}
+
 /* Details/Summary chevron rotation */
 details[open] .details-open-rotate {
   transform: rotate(180deg);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { LpHeader } from "@/components/lp/lp-header";
 import { HeroSection } from "@/components/lp/hero-section";
 import { ProblemSection } from "@/components/lp/problem-section";
 import { FeaturesSection } from "@/components/lp/features-section";
-import { ScreenshotSection } from "@/components/lp/screenshot-section";
+import { AppShowcaseSection } from "@/components/lp/app-showcase-section";
 import { PricingSection } from "@/components/lp/pricing-section";
 import { ComparisonSection } from "@/components/lp/comparison-section";
 import { StepsSection } from "@/components/lp/steps-section";
@@ -59,7 +59,7 @@ export default async function HomePage() {
         <HeroSection />
         <ProblemSection />
         <FeaturesSection />
-        <ScreenshotSection />
+        <AppShowcaseSection />
         <PricingSection />
         <ComparisonSection />
         <StepsSection />

--- a/src/components/lp/app-showcase-section.tsx
+++ b/src/components/lp/app-showcase-section.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/** アプリショーケース — タブ切替でアプリ画面をインタラクティブに見せる */
+
+import { useState } from "react";
+import { PhoneFrame } from "./phone-frame";
+import {
+  MockKarteScreen,
+  MockAppointmentScreen,
+  MockCustomerScreen,
+  MockSalesScreen,
+} from "./mockup-screens";
+
+const TABS = [
+  {
+    key: "karte",
+    label: "カルテ",
+    caption: "施術内容・写真・メモをスマホからサッと記録。お客様が帰った後に3分で完了。",
+    icon: "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z",
+    Screen: MockKarteScreen,
+  },
+  {
+    key: "appointment",
+    label: "予約",
+    caption: "予約の一覧・空き確認・LINE自動通知。ダブルブッキングを完全防止。",
+    icon: "M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5",
+    Screen: MockAppointmentScreen,
+  },
+  {
+    key: "customer",
+    label: "顧客",
+    caption: "来店履歴・好み・回数券をひと目で確認。「また来たい」をサポート。",
+    icon: "M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z",
+    Screen: MockCustomerScreen,
+  },
+  {
+    key: "sales",
+    label: "売上",
+    caption: "売上推移・内訳・確定申告レポート。数字の管理をアプリにおまかせ。",
+    icon: "M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z",
+    Screen: MockSalesScreen,
+  },
+] as const;
+
+export function AppShowcaseSection() {
+  const [active, setActive] = useState(0);
+  const tab = TABS[active];
+
+  return (
+    <section className="py-16 md:py-24 bg-white overflow-hidden">
+      <div className="max-w-5xl mx-auto px-4">
+        {/* 見出し */}
+        <div className="text-center mb-10">
+          <h2 className="text-3xl md:text-4xl font-bold mb-4">
+            使いやすさを、見てください
+          </h2>
+          <p className="text-text-light text-lg">
+            直感的な画面で、ITが苦手でもすぐに使いこなせます
+          </p>
+        </div>
+
+        {/* タブ */}
+        <div className="flex justify-center mb-10">
+          <div className="inline-flex bg-background rounded-2xl p-1.5 border border-border/50 gap-1">
+            {TABS.map((t, i) => (
+              <button
+                key={t.key}
+                onClick={() => setActive(i)}
+                className={`flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-medium transition-all min-h-[44px] ${
+                  i === active
+                    ? "bg-accent text-white shadow-md shadow-accent/20"
+                    : "text-text-light hover:text-text hover:bg-white/60"
+                }`}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d={t.icon} />
+                </svg>
+                <span className="hidden sm:inline">{t.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* スマホモックアップ + キャプション */}
+        <div className="flex flex-col md:flex-row items-center justify-center gap-8 md:gap-16">
+          <div className="animate-float-phone">
+            <PhoneFrame key={tab.key}>
+              <div className="animate-screen-fade-in">
+                <tab.Screen />
+              </div>
+            </PhoneFrame>
+          </div>
+
+          <div className="max-w-sm text-center md:text-left">
+            <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center text-accent mb-4 mx-auto md:mx-0">
+              <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d={tab.icon} />
+              </svg>
+            </div>
+            <h3 className="text-2xl font-bold mb-3">{tab.label}管理</h3>
+            <p className="text-text-light leading-relaxed">{tab.caption}</p>
+            <div className="mt-6 flex flex-wrap justify-center md:justify-start gap-2">
+              {TABS.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => setActive(i)}
+                  className={`w-2.5 h-2.5 rounded-full transition-all ${
+                    i === active ? "bg-accent scale-125" : "bg-border hover:bg-accent/40"
+                  }`}
+                  aria-label={`${TABS[i].label}画面を表示`}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/lp/features-section.tsx
+++ b/src/components/lp/features-section.tsx
@@ -1,19 +1,25 @@
-/** 機能ベネフィット 4 カード */
+/** 機能ベネフィット — 交互レイアウト + ミニモックアップ */
 
 import { ScrollFadeIn } from "./scroll-fade-in";
+import { PhoneFrame } from "./phone-frame";
+import {
+  MockKarteScreen,
+  MockAppointmentScreen,
+  MockCustomerScreen,
+  MockSalesScreen,
+} from "./mockup-screens";
 
 const FEATURES = [
   {
     title: "カルテを3分で記録",
     description:
-      "施術内容・写真・カウンセリングをスマホからサッと記録。お客様が帰った後に3分で完了。",
+      "施術内容・写真・カウンセリングをスマホからサッと記録。紙のカルテを探す手間がゼロに。",
     details: [
       "施術写真のビフォーアフター",
       "デジタルカウンセリングシート",
       "施術メニュー・料金の自動記録",
     ],
-    iconPath:
-      "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z",
+    Screen: MockKarteScreen,
   },
   {
     title: "LINEで予約もリマインドも自動",
@@ -24,20 +30,7 @@ const FEATURES = [
       "自動リマインド通知",
       "空き時間のリアルタイム表示",
     ],
-    iconPath:
-      "M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z",
-  },
-  {
-    title: "売上も在庫も確定申告もラクに",
-    description:
-      "売上レポート・在庫管理・確定申告サポートが全部入り。数字の管理をアプリにおまかせ。",
-    details: [
-      "月次・年次売上レポート",
-      "商品在庫の自動管理",
-      "確定申告用データ出力",
-    ],
-    iconPath:
-      "M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z",
+    Screen: MockAppointmentScreen,
   },
   {
     title: "お客様との関係を深める",
@@ -46,10 +39,20 @@ const FEATURES = [
     details: [
       "離脱リスク顧客の自動検知",
       "顧客ランク・LTV分析",
-      "来店履歴の完全記録",
+      "回数券・来店履歴の完全記録",
     ],
-    iconPath:
-      "M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z",
+    Screen: MockCustomerScreen,
+  },
+  {
+    title: "売上も在庫も確定申告もラクに",
+    description:
+      "売上レポート・在庫管理・確定申告サポートが全部入り。数字の管理をアプリにおまかせ。",
+    details: [
+      "月次・年次売上レポート",
+      "商品在庫の自動管理",
+      "確定申告用CSV出力",
+    ],
+    Screen: MockSalesScreen,
   },
 ];
 
@@ -58,7 +61,7 @@ export function FeaturesSection() {
     <section className="py-16 md:py-24 bg-[#F5F1ED]">
       <div className="max-w-5xl mx-auto px-4">
         <ScrollFadeIn>
-          <div className="text-center mb-12">
+          <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
               サロン運営に必要な機能が、
               <br className="md:hidden" />
@@ -70,40 +73,57 @@ export function FeaturesSection() {
           </div>
         </ScrollFadeIn>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {FEATURES.map((f, i) => (
-            <ScrollFadeIn key={f.title} delay={i * 100}>
-              <div className="bg-white rounded-2xl p-6 border border-border/50 hover:shadow-[var(--shadow-card-hover)] transition-shadow h-full">
-                <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center text-accent mb-4">
-                  <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d={f.iconPath} />
-                  </svg>
-                </div>
-                <h3 className="text-xl font-bold mb-2">{f.title}</h3>
-                <p className="text-text-light text-sm leading-relaxed mb-4">
-                  {f.description}
-                </p>
-                <ul className="space-y-1.5">
-                  {f.details.map((d) => (
-                    <li key={d} className="flex items-center gap-2 text-sm text-text-light">
-                      <CheckIcon />
-                      {d}
-                    </li>
-                  ))}
-                </ul>
+        <div className="space-y-20 md:space-y-28">
+          {FEATURES.map((f, i) => {
+            const reverse = i % 2 === 1;
+            return (
+              <div
+                key={f.title}
+                className={`flex flex-col items-center gap-10 md:gap-16 ${
+                  reverse ? "md:flex-row-reverse" : "md:flex-row"
+                }`}
+              >
+                {/* ミニモックアップ */}
+                <ScrollFadeIn
+                  direction={reverse ? "right" : "left"}
+                  delay={100}
+                  className="flex-shrink-0"
+                >
+                  <div className="scale-90 md:scale-100">
+                    <PhoneFrame minHeight={420} glow={false}>
+                      <f.Screen />
+                    </PhoneFrame>
+                  </div>
+                </ScrollFadeIn>
+
+                {/* テキスト */}
+                <ScrollFadeIn
+                  direction={reverse ? "left" : "right"}
+                  delay={200}
+                  className="flex-1 text-center md:text-left"
+                >
+                  <h3 className="text-2xl md:text-3xl font-bold mb-4">{f.title}</h3>
+                  <p className="text-text-light text-base leading-relaxed mb-6 max-w-md mx-auto md:mx-0">
+                    {f.description}
+                  </p>
+                  <ul className="space-y-3 inline-block text-left">
+                    {f.details.map((d) => (
+                      <li key={d} className="flex items-center gap-3 text-sm">
+                        <span className="flex-shrink-0 w-6 h-6 rounded-full bg-accent/10 flex items-center justify-center">
+                          <svg className="w-3.5 h-3.5 text-accent" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                          </svg>
+                        </span>
+                        {d}
+                      </li>
+                    ))}
+                  </ul>
+                </ScrollFadeIn>
               </div>
-            </ScrollFadeIn>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>
-  );
-}
-
-function CheckIcon() {
-  return (
-    <svg className="w-4 h-4 text-accent flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-    </svg>
   );
 }

--- a/src/components/lp/hero-section.tsx
+++ b/src/components/lp/hero-section.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { BrandLogo } from "@/components/ui/brand-logo";
 import { ScrollFadeIn } from "./scroll-fade-in";
+import { PhoneFrame } from "./phone-frame";
 
 export function HeroSection() {
   return (
@@ -55,7 +56,11 @@ export function HeroSection() {
 
           {/* スマホモックアップ */}
           <ScrollFadeIn direction="right" delay={300} className="flex-shrink-0">
-            <PhoneMockup />
+            <div className="animate-float-phone">
+              <PhoneFrame>
+                <HeroDashboard />
+              </PhoneFrame>
+            </div>
           </ScrollFadeIn>
         </div>
       </div>
@@ -63,53 +68,39 @@ export function HeroSection() {
   );
 }
 
-/** CSS製スマホフレーム — ダッシュボード画面 */
-function PhoneMockup() {
+/** ヒーロー用ダッシュボード画面 */
+function HeroDashboard() {
   return (
-    <div className="relative animate-float-phone">
-      <div className="absolute inset-0 bg-accent/10 rounded-[44px] blur-2xl scale-105" />
-      <div className="relative w-[260px] md:w-[280px] bg-white rounded-[36px] border-[6px] border-[#2D2D2D] shadow-2xl overflow-hidden">
-        {/* ノッチ */}
-        <div className="bg-[#2D2D2D] h-7 flex items-center justify-center">
-          <div className="w-20 h-4 bg-[#1a1a1a] rounded-full" />
-        </div>
-        {/* ダッシュボード */}
-        <div className="bg-background p-3 space-y-3" style={{ minHeight: 460 }}>
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-bold text-text">ダッシュボード</span>
-            <div className="w-6 h-6 rounded-full bg-accent/20" />
+    <div className="p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-bold text-text">ダッシュボード</span>
+        <div className="w-6 h-6 rounded-full bg-accent/20" />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <MockCard label="今日の予約" value="3件" accent />
+        <MockCard label="今月の売上" value="¥248,500" />
+      </div>
+      <div className="bg-white rounded-xl p-2.5 border border-border space-y-2">
+        <span className="text-[10px] font-bold text-text-light">本日の予約</span>
+        {[
+          { t: "10:00", n: "田中 様", m: "カット+カラー" },
+          { t: "13:00", n: "佐藤 様", m: "トリートメント" },
+          { t: "15:30", n: "鈴木 様", m: "パーマ" },
+        ].map((a) => (
+          <div key={a.t} className="flex items-center gap-2 py-1 border-b border-border/50 last:border-0">
+            <span className="text-[10px] font-medium text-accent w-8">{a.t}</span>
+            <span className="text-[10px] font-medium flex-1">{a.n}</span>
+            <span className="text-[9px] text-text-light">{a.m}</span>
           </div>
-          <div className="grid grid-cols-2 gap-2">
-            <MockCard label="今日の予約" value="3件" accent />
-            <MockCard label="今月の売上" value="¥248,500" />
+        ))}
+      </div>
+      <div className="grid grid-cols-4 gap-1.5">
+        {["カルテ", "予約", "顧客", "売上"].map((l) => (
+          <div key={l} className="bg-white rounded-lg p-2 text-center border border-border">
+            <div className="w-5 h-5 rounded-full bg-accent/10 mx-auto mb-1" />
+            <span className="text-[9px] text-text-light">{l}</span>
           </div>
-          <div className="bg-white rounded-xl p-2.5 border border-border space-y-2">
-            <span className="text-[10px] font-bold text-text-light">本日の予約</span>
-            {[
-              { t: "10:00", n: "田中 様", m: "カット+カラー" },
-              { t: "13:00", n: "佐藤 様", m: "トリートメント" },
-              { t: "15:30", n: "鈴木 様", m: "パーマ" },
-            ].map((a) => (
-              <div key={a.t} className="flex items-center gap-2 py-1 border-b border-border/50 last:border-0">
-                <span className="text-[10px] font-medium text-accent w-8">{a.t}</span>
-                <span className="text-[10px] font-medium flex-1">{a.n}</span>
-                <span className="text-[9px] text-text-light">{a.m}</span>
-              </div>
-            ))}
-          </div>
-          <div className="grid grid-cols-4 gap-1.5">
-            {["カルテ", "予約", "顧客", "売上"].map((l) => (
-              <div key={l} className="bg-white rounded-lg p-2 text-center border border-border">
-                <div className="w-5 h-5 rounded-full bg-accent/10 mx-auto mb-1" />
-                <span className="text-[9px] text-text-light">{l}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        {/* ホームバー */}
-        <div className="bg-white border-t border-border h-5 flex items-center justify-center">
-          <div className="w-24 h-1 bg-border rounded-full" />
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/lp/mockup-screens.tsx
+++ b/src/components/lp/mockup-screens.tsx
@@ -1,0 +1,272 @@
+/** LP用モックアプリ画面 — 実データ不要のプログラマティック描画 */
+
+/** カルテ記録画面 */
+export function MockKarteScreen() {
+  return (
+    <div className="p-3 space-y-2.5 text-[10px]">
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-xs text-text">カルテ新規作成</span>
+        <span className="text-accent text-[9px]">3/6</span>
+      </div>
+      {/* 顧客名 */}
+      <div className="bg-white rounded-xl p-2.5 border border-border">
+        <span className="text-[9px] text-text-light">お客様</span>
+        <div className="font-bold text-sm mt-0.5">田中 美咲 様</div>
+      </div>
+      {/* メニュー */}
+      <div className="bg-white rounded-xl p-2.5 border border-border space-y-1.5">
+        <span className="font-bold text-text-light">施術メニュー</span>
+        <div className="flex justify-between items-center py-1 border-b border-border/50">
+          <div className="flex items-center gap-1.5">
+            <div className="w-1.5 h-1.5 rounded-full bg-accent" />
+            <span>カット+カラー</span>
+          </div>
+          <span className="font-medium">¥12,000</span>
+        </div>
+        <div className="flex justify-between items-center py-1">
+          <div className="flex items-center gap-1.5">
+            <div className="w-1.5 h-1.5 rounded-full bg-accent" />
+            <span>トリートメント</span>
+          </div>
+          <span className="font-medium">¥3,000</span>
+        </div>
+      </div>
+      {/* 写真 */}
+      <div className="bg-white rounded-xl p-2.5 border border-border">
+        <span className="font-bold text-text-light">施術写真</span>
+        <div className="flex gap-2 mt-1.5">
+          <div className="flex-1 aspect-square rounded-lg bg-gradient-to-br from-amber-100 to-amber-200 flex items-center justify-center">
+            <span className="text-[8px] text-amber-600 font-medium">Before</span>
+          </div>
+          <div className="flex-1 aspect-square rounded-lg bg-gradient-to-br from-accent/20 to-accent/40 flex items-center justify-center">
+            <span className="text-[8px] text-accent font-medium">After</span>
+          </div>
+        </div>
+      </div>
+      {/* メモ */}
+      <div className="bg-white rounded-xl p-2.5 border border-border">
+        <span className="font-bold text-text-light">メモ</span>
+        <p className="mt-1 text-text leading-relaxed">前回より明るめカラー。次回パーマも検討中。</p>
+      </div>
+      {/* 合計 */}
+      <div className="bg-accent text-white rounded-xl p-3 text-center">
+        <span className="text-[9px] opacity-80">合計金額</span>
+        <div className="text-lg font-bold">¥15,000</div>
+      </div>
+    </div>
+  );
+}
+
+/** 予約管理画面 */
+export function MockAppointmentScreen() {
+  const slots = [
+    { time: "10:00", name: "田中 美咲", menu: "カット+カラー", color: "bg-accent/15 border-accent/30 text-accent" },
+    { time: "13:00", name: "佐藤 花", menu: "トリートメント", color: "bg-emerald-50 border-emerald-200 text-emerald-700" },
+    { time: "15:30", name: "鈴木 あい", menu: "パーマ", color: "bg-violet-50 border-violet-200 text-violet-700" },
+    { time: "17:00", name: "", menu: "", color: "" },
+  ];
+  return (
+    <div className="p-3 space-y-2.5 text-[10px]">
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-xs text-text">予約管理</span>
+        <div className="flex items-center gap-1">
+          <ChevronIcon dir="left" />
+          <span className="text-accent font-bold text-[11px]">3月6日(木)</span>
+          <ChevronIcon dir="right" />
+        </div>
+      </div>
+      {/* タイムライン */}
+      <div className="space-y-1.5">
+        {slots.map((s) => (
+          <div key={s.time} className={`rounded-xl p-2.5 border ${s.name ? s.color : "bg-white border-border border-dashed"}`}>
+            <div className="flex items-center gap-2">
+              <span className="font-bold w-8 text-[11px]">{s.time}</span>
+              {s.name ? (
+                <div className="flex-1">
+                  <div className="font-bold text-[11px]">{s.name} 様</div>
+                  <div className="text-[9px] opacity-70">{s.menu}</div>
+                </div>
+              ) : (
+                <span className="text-text-light italic">空き</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* LINE通知バッジ */}
+      <div className="bg-[#06C755]/10 rounded-xl p-2.5 border border-[#06C755]/20 flex items-center gap-2">
+        <div className="w-6 h-6 rounded-full bg-[#06C755] flex items-center justify-center flex-shrink-0">
+          <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-white" fill="currentColor">
+            <path d="M12 2C6.48 2 2 5.92 2 10.66c0 2.78 1.56 5.24 4 6.86v3.48l3.14-1.72c.92.26 1.88.4 2.86.4 5.52 0 10-3.92 10-8.68S17.52 2 12 2z" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-bold text-[#06C755]">LINE通知 ON</div>
+          <div className="text-[9px] text-text-light">予約確認・前日リマインド自動送信</div>
+        </div>
+      </div>
+      {/* 追加ボタン */}
+      <div className="bg-accent text-white rounded-xl p-2.5 text-center font-bold text-[11px]">
+        + 予約を登録
+      </div>
+    </div>
+  );
+}
+
+/** 顧客詳細画面 */
+export function MockCustomerScreen() {
+  return (
+    <div className="p-3 space-y-2.5 text-[10px]">
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-xs text-text">顧客詳細</span>
+      </div>
+      {/* プロフィール */}
+      <div className="bg-white rounded-xl p-3 border border-border text-center">
+        <div className="w-12 h-12 rounded-full bg-gradient-to-br from-accent/30 to-accent/60 mx-auto mb-2 flex items-center justify-center">
+          <span className="text-white font-bold text-sm">田</span>
+        </div>
+        <div className="font-bold text-sm">田中 美咲 様</div>
+        <div className="text-[9px] text-text-light mt-0.5">最終来店: 3/1 ・ 常連</div>
+      </div>
+      {/* 統計カード */}
+      <div className="grid grid-cols-3 gap-1.5">
+        <StatMini label="来店回数" value="12回" />
+        <StatMini label="累計売上" value="¥156K" accent />
+        <StatMini label="来店間隔" value="21日" />
+      </div>
+      {/* 施術履歴 */}
+      <div className="bg-white rounded-xl p-2.5 border border-border space-y-1.5">
+        <span className="font-bold text-text-light">施術履歴</span>
+        {[
+          { date: "3/1", menu: "カット+カラー", price: "¥12,000" },
+          { date: "2/15", menu: "トリートメント", price: "¥3,000" },
+          { date: "2/1", menu: "カット", price: "¥5,500" },
+        ].map((h) => (
+          <div key={h.date} className="flex items-center py-1 border-b border-border/50 last:border-0">
+            <span className="text-text-light w-7">{h.date}</span>
+            <span className="flex-1 font-medium">{h.menu}</span>
+            <span className="font-medium">{h.price}</span>
+          </div>
+        ))}
+      </div>
+      {/* メモ・好み */}
+      <div className="bg-white rounded-xl p-2.5 border border-border">
+        <span className="font-bold text-text-light">好み・メモ</span>
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {["明るめカラー", "敏感肌", "パーマ検討中"].map((t) => (
+            <span key={t} className="bg-accent/10 text-accent rounded-full px-2 py-0.5 text-[9px] font-medium">{t}</span>
+          ))}
+        </div>
+      </div>
+      {/* 回数券 */}
+      <div className="bg-gradient-to-r from-accent/10 to-accent/5 rounded-xl p-2.5 border border-accent/20">
+        <div className="flex justify-between items-center">
+          <span className="font-bold text-accent">ヘッドスパ回数券</span>
+          <span className="text-accent font-bold text-[11px]">残3回</span>
+        </div>
+        <div className="flex gap-0.5 mt-1">
+          {[1,2,3,4,5].map((i) => (
+            <div key={i} className={`flex-1 h-1.5 rounded-full ${i <= 2 ? "bg-accent" : "bg-accent/20"}`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 売上レポート画面 */
+export function MockSalesScreen() {
+  const months = [
+    { label: "10月", h: 45 },
+    { label: "11月", h: 55 },
+    { label: "12月", h: 70 },
+    { label: "1月", h: 50 },
+    { label: "2月", h: 65 },
+    { label: "3月", h: 80, current: true },
+  ];
+  return (
+    <div className="p-3 space-y-2.5 text-[10px]">
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-xs text-text">売上レポート</span>
+        <span className="text-accent text-[9px] font-medium">2026年3月</span>
+      </div>
+      {/* メイン指標 */}
+      <div className="bg-white rounded-xl p-3 border border-border text-center">
+        <span className="text-text-light">月間売上</span>
+        <div className="text-2xl font-bold text-text mt-0.5">¥482,000</div>
+        <div className="inline-flex items-center gap-1 bg-emerald-50 text-emerald-600 rounded-full px-2 py-0.5 text-[9px] font-medium mt-1">
+          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+          </svg>
+          前月比 +12.3%
+        </div>
+      </div>
+      {/* バーチャート */}
+      <div className="bg-white rounded-xl p-3 border border-border">
+        <span className="font-bold text-text-light">月別推移</span>
+        <div className="flex items-end justify-between gap-1.5 mt-2 h-20">
+          {months.map((m) => (
+            <div key={m.label} className="flex-1 flex flex-col items-center gap-1">
+              <div
+                className={`w-full rounded-t-md transition-all ${m.current ? "bg-accent" : "bg-accent/25"}`}
+                style={{ height: `${m.h}%` }}
+              />
+              <span className={`text-[8px] ${m.current ? "text-accent font-bold" : "text-text-light"}`}>
+                {m.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* 内訳 */}
+      <div className="bg-white rounded-xl p-2.5 border border-border space-y-1.5">
+        <span className="font-bold text-text-light">売上内訳</span>
+        <BreakdownRow label="施術" amount="¥398,000" pct={83} color="bg-accent" />
+        <BreakdownRow label="物販" amount="¥84,000" pct={17} color="bg-emerald-400" />
+      </div>
+      {/* 確定申告 */}
+      <div className="bg-blue-50 rounded-xl p-2.5 border border-blue-200 flex items-center gap-2">
+        <svg className="w-5 h-5 text-blue-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+        </svg>
+        <div>
+          <div className="font-bold text-blue-700 text-[10px]">確定申告レポート</div>
+          <div className="text-[9px] text-blue-600">CSV出力でかんたん申告</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 内部ヘルパー ── */
+
+function StatMini({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="bg-white rounded-lg p-2 text-center border border-border">
+      <div className="text-[8px] text-text-light">{label}</div>
+      <div className={`text-[11px] font-bold ${accent ? "text-accent" : "text-text"}`}>{value}</div>
+    </div>
+  );
+}
+
+function BreakdownRow({ label, amount, pct, color }: { label: string; amount: string; pct: number; color: string }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="flex justify-between">
+        <span>{label}</span>
+        <span className="font-medium">{amount}</span>
+      </div>
+      <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function ChevronIcon({ dir }: { dir: "left" | "right" }) {
+  return (
+    <svg className="w-3.5 h-3.5 text-text-light" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d={dir === "left" ? "M15.75 19.5 8.25 12l7.5-7.5" : "m8.25 4.5 7.5 7.5-7.5 7.5"} />
+    </svg>
+  );
+}

--- a/src/components/lp/phone-frame.tsx
+++ b/src/components/lp/phone-frame.tsx
@@ -1,0 +1,41 @@
+/** 再利用可能なスマホモックアップフレーム */
+
+import type { ReactNode } from "react";
+
+interface PhoneFrameProps {
+  children: ReactNode;
+  className?: string;
+  /** フレーム内コンテンツの最小高さ（デフォルト: 460px） */
+  minHeight?: number;
+  /** グロー効果を表示するか */
+  glow?: boolean;
+}
+
+export function PhoneFrame({
+  children,
+  className = "",
+  minHeight = 460,
+  glow = true,
+}: PhoneFrameProps) {
+  return (
+    <div className={`relative ${className}`}>
+      {glow && (
+        <div className="absolute inset-0 bg-accent/10 rounded-[44px] blur-2xl scale-105" />
+      )}
+      <div className="relative w-[260px] md:w-[280px] bg-white rounded-[36px] border-[6px] border-[#2D2D2D] shadow-2xl overflow-hidden">
+        {/* ノッチ */}
+        <div className="bg-[#2D2D2D] h-7 flex items-center justify-center">
+          <div className="w-20 h-4 bg-[#1a1a1a] rounded-full" />
+        </div>
+        {/* コンテンツ */}
+        <div className="bg-background overflow-hidden" style={{ minHeight }}>
+          {children}
+        </div>
+        {/* ホームバー */}
+        <div className="bg-white border-t border-border h-5 flex items-center justify-center">
+          <div className="w-24 h-1 bg-border rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- PhoneFrame共通コンポーネントを抽出（ヒーロー・ショーケース・機能紹介で共有）
- 4つのリアルなモックアプリ画面を作成（カルテ・予約・顧客・売上）
- AppShowcaseSection: タブ切替でアプリ画面をインタラクティブに見せる新セクション
- FeaturesSection: カード2x2から交互レイアウト+ミニモックアップに全面リニューアル
- スクリーンショット不要のメンテナンスフリーなアプローチ

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01MzsN2PRYWwd4v5rGbuVziu