### PR TITLE
feat: LINE設定の用語改善・FAQ追加・ヘルプ吹き出しコンポーネント

### DIFF
--- a/src/app/(dashboard)/settings/booking-rules/page.tsx
+++ b/src/app/(dashboard)/settings/booking-rules/page.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Toast, useToast } from "@/components/ui/toast";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { HelpTip } from "@/components/ui/help-tip";
 import type { BookingSettings } from "@/types/database";
 
 const LEAD_TIME_OPTIONS = [
@@ -162,7 +163,10 @@ export default function BookingRulesPage() {
 
         {/* 受付締切時間 */}
         <div className="space-y-2">
-          <h3 className="font-bold text-sm">受付締切時間</h3>
+          <h3 className="font-bold text-sm">
+            受付締切時間
+            <HelpTip>例えば「2時間前まで」に設定すると、14時の予約は12時までしか受け付けません。準備時間が必要な場合に設定してください。</HelpTip>
+          </h3>
           <p className="text-xs text-text-light">
             予約の何時間前まで受け付けるか（当日以外も適用）
           </p>
@@ -181,9 +185,12 @@ export default function BookingRulesPage() {
 
         {/* 同時予約数の上限 */}
         <div className="space-y-2">
-          <h3 className="font-bold text-sm">同時予約数の上限</h3>
+          <h3 className="font-bold text-sm">
+            同時予約数の上限
+            <HelpTip>お一人で運営されている場合は「1」のままで大丈夫です。スタッフが複数いる場合やベッドが複数ある場合に数を増やしてください。</HelpTip>
+          </h3>
           <p className="text-xs text-text-light">
-            同じ時間帯に受けられる予約の最大数（ベッド・部屋の数に合わせて設定）
+            同じ時間帯に受けられる予約の最大数
           </p>
           <select
             value={settings.max_concurrent_appointments}
@@ -200,9 +207,12 @@ export default function BookingRulesPage() {
 
         {/* キャンセル・変更締切 */}
         <div className="space-y-2">
-          <h3 className="font-bold text-sm">キャンセル・変更締切</h3>
+          <h3 className="font-bold text-sm">
+            キャンセル・変更締切
+            <HelpTip>お客様がWeb予約ページからキャンセル・変更できる期限です。「制限なし」だと直前でも変更可能です。ドタキャンを防ぎたい場合は「24時間前」などに設定してください。</HelpTip>
+          </h3>
           <p className="text-xs text-text-light">
-            お客様がWeb予約のキャンセル・変更をできる期限（予約の何時間前まで）
+            お客様がWeb予約のキャンセル・変更をできる期限
           </p>
           <select
             value={settings.change_deadline_hours ?? 0}

--- a/src/app/(dashboard)/settings/line/page.tsx
+++ b/src/app/(dashboard)/settings/line/page.tsx
@@ -60,25 +60,64 @@ export default function LineSettingsPage() {
         <LineSetupGuide onConnected={setConfig} />
       )}
 
+      {/* よくある質問 */}
+      <details className="bg-surface border border-border rounded-xl">
+        <summary className="font-bold text-sm p-4 cursor-pointer min-h-[44px] flex items-center">
+          よくある質問・トラブル対応
+        </summary>
+        <div className="px-4 pb-4 space-y-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">LINEの通知が届きません</p>
+            <p className="text-xs text-text-light leading-relaxed">
+              ① 上の「LINE連携を有効にする」がONになっているか確認してください。
+              ② 受信用アドレス（Webhook URL）がLINE側に正しく登録されているか確認してください。
+              ③ LINE側で「Webhookの利用」がONになっているか確認してください。
+              ④ お客様がLINE友だちと紐付けされているか、顧客詳細ページで確認してください。
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium">顧客とLINE友だちの紐付け方がわかりません</p>
+            <p className="text-xs text-text-light leading-relaxed">
+              2つの方法があります。①このページ下部の「LINE友だち管理」から紐付ける方法。②各顧客の詳細ページにある「LINE連携」セクションから紐付ける方法。
+              まず「友だちを同期」ボタンを押して、LINE公式アカウントの友だちを取り込んでください。
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium">「接続番号」「秘密キー」「送信キー」はどこにありますか？</p>
+            <p className="text-xs text-text-light leading-relaxed">
+              <a href="https://developers.line.biz/console/" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline font-medium">
+                LINE Developers
+              </a>
+              にログインし、お使いのアカウントを選択してください。
+              「チャネル基本設定」タブに接続番号と秘密キー、「Messaging API設定」タブに送信キー（アクセストークン）があります。
+            </p>
+          </div>
+        </div>
+      </details>
+
       {/* LINEプラン制限の説明 */}
-      <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
-        <h3 className="font-bold text-sm">LINE公式アカウントの通数制限について</h3>
-        <p className="text-xs text-text-light leading-relaxed">
-          予約確認・リマインドなどのメッセージは、LINE公式アカウントの無料通数（月200通）を消費します。
-          1日あたり平均5〜10件の予約通知であれば無料枠内で運用できます。
-        </p>
-        <p className="text-xs text-text-light leading-relaxed">
-          月200通を超える場合は、LINE公式アカウントの有料プラン（ライトプラン: 月5,000通 / 5,000円）へのアップグレードをご検討ください。
-        </p>
-        <a
-          href="https://www.lycbiz.com/jp/service/line-official-account/plan/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block text-xs text-accent hover:underline"
-        >
-          LINE公式アカウントの料金プランを確認する &rarr;
-        </a>
-      </div>
+      <details className="bg-surface border border-border rounded-xl">
+        <summary className="font-bold text-sm p-4 cursor-pointer min-h-[44px] flex items-center">
+          LINE公式アカウントの通数制限について
+        </summary>
+        <div className="px-4 pb-4 space-y-2">
+          <p className="text-xs text-text-light leading-relaxed">
+            予約確認・リマインドなどのメッセージは、LINE公式アカウントの無料通数（月200通）を消費します。
+            1日あたり平均5〜10件の予約通知であれば無料枠内で運用できます。
+          </p>
+          <p className="text-xs text-text-light leading-relaxed">
+            月200通を超える場合は、LINE公式アカウントの有料プラン（ライトプラン: 月5,000通 / 5,000円）へのアップグレードをご検討ください。
+          </p>
+          <a
+            href="https://www.lycbiz.com/jp/service/line-official-account/plan/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-xs text-accent hover:underline"
+          >
+            LINE公式アカウントの料金プランを確認する &rarr;
+          </a>
+        </div>
+      </details>
     </div>
   );
 }

--- a/src/app/(dashboard)/settings/web-booking/page.tsx
+++ b/src/app/(dashboard)/settings/web-booking/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Toast, useToast } from "@/components/ui/toast";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { HelpTip } from "@/components/ui/help-tip";
 
 export default function WebBookingSettingsPage() {
   const [salonId, setSalonId] = useState("");
@@ -161,7 +162,10 @@ export default function WebBookingSettingsPage() {
         {/* 公開 ON/OFF（即時保存） */}
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="font-bold text-sm">予約ページを公開</h3>
+            <h3 className="font-bold text-sm">
+              予約ページを公開
+              <HelpTip>ONにするとお客様がURLから直接予約できるようになります。OFFにしても既存の予約には影響ありません。</HelpTip>
+            </h3>
             <p className="text-xs text-text-light mt-0.5">
               切り替えると即座に反映されます
             </p>
@@ -186,7 +190,10 @@ export default function WebBookingSettingsPage() {
 
         {/* 予約ページ URL */}
         <div className="space-y-2">
-          <h3 className="font-bold text-sm">予約ページURL</h3>
+          <h3 className="font-bold text-sm">
+            予約ページURL
+            <HelpTip>お客様に共有するURLです。サロン名やブランド名をローマ字で入力してください。例: my-salon, beauty-room など。</HelpTip>
+          </h3>
           <div className="flex items-center gap-1 text-sm text-text-light">
             <span className="shrink-0">/book/</span>
             <input

--- a/src/components/settings/line-setup-guide.tsx
+++ b/src/components/settings/line-setup-guide.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { Toast, useToast } from "@/components/ui/toast";
+import { HelpTip } from "@/components/ui/help-tip";
 
 type LineConfig = {
   id: string;
@@ -63,53 +64,53 @@ export function LineSetupGuide({ onConnected }: Props) {
 
       {/* 手順ガイド */}
       <div className="bg-accent/5 border border-accent/20 rounded-2xl p-4 space-y-4">
-        <p className="font-bold text-sm">LINE公式アカウントを連携する手順</p>
+        <p className="font-bold text-sm">LINE公式アカウントと連携する手順（約5分）</p>
 
         {/* ステップ1 */}
         <div className="space-y-1">
-          <p className="text-sm font-medium">① LINE公式アカウントを作成</p>
+          <p className="text-sm font-medium">① LINE公式アカウントを用意する</p>
           <p className="text-xs text-text-light leading-relaxed">
-            まだLINE公式アカウントをお持ちでない場合は、
+            まだお持ちでない場合は、
             <a href="https://manager.line.biz/" target="_blank" rel="noopener noreferrer" className={linkClass}>
-              LINE Official Account Manager
+              LINE公式アカウント管理画面
             </a>
             から無料で作成できます。
           </p>
-          <p className="text-xs text-text-light">※ 無料プラン（月200通まで）で十分です。既にお持ちの場合は次へ進んでください。</p>
+          <p className="text-xs text-text-light">※ 無料プラン（月200通まで）で十分です。既にお持ちの場合は②へ。</p>
         </div>
 
         {/* ステップ2 */}
         <div className="space-y-1">
-          <p className="text-sm font-medium">② Messaging APIを有効にする</p>
+          <p className="text-sm font-medium">② LINE公式アカウントの「メッセージ送信機能」を有効にする</p>
           <p className="text-xs text-text-light leading-relaxed">
             <a href="https://manager.line.biz/" target="_blank" rel="noopener noreferrer" className={linkClass}>
-              LINE Official Account Manager
+              LINE公式アカウント管理画面
             </a>
             にログインし、右上の「設定」→ 左メニューの「Messaging API」→「Messaging APIを利用する」ボタンを押してください。
           </p>
           <p className="text-xs text-text-light">
-            ※ プロバイダー名の入力を求められます。サロン名などを入力してください（後から変更できません）。
+            ※ 「プロバイダー名」にはサロン名などを入力してください。
           </p>
         </div>
 
         {/* ステップ3 */}
         <div className="space-y-1">
-          <p className="text-sm font-medium">③ 認証情報をコピーして下のフォームに貼り付け</p>
+          <p className="text-sm font-medium">③ 3つの接続番号をコピーして下のフォームに貼り付ける</p>
           <p className="text-xs text-text-light leading-relaxed">
             <a href="https://developers.line.biz/console/" target="_blank" rel="noopener noreferrer" className={linkClass}>
-              LINE Developers Console
+              LINE Developers（開発者向け管理画面）
             </a>
-            を開き、②で作成されたチャネルを選択してください。
+            を開き、②で作成されたアカウントを選んでください。
           </p>
           <div className="bg-white/50 rounded-lg p-3 space-y-1.5 mt-1.5">
             <p className="text-xs text-text-light">
-              <span className="font-medium text-text">チャネルID</span>：「チャネル基本設定」タブに表示されています
+              <span className="font-medium text-text">接続番号（チャネルID）</span>：「チャネル基本設定」タブに表示されている数字
             </p>
             <p className="text-xs text-text-light">
-              <span className="font-medium text-text">チャネルシークレット</span>：「チャネル基本設定」タブの下部にあります
+              <span className="font-medium text-text">秘密キー（チャネルシークレット）</span>：同じタブの下部にある英数字の文字列
             </p>
             <p className="text-xs text-text-light">
-              <span className="font-medium text-text">チャネルアクセストークン</span>：「Messaging API設定」タブ →「チャネルアクセストークン（長期）」の「発行」ボタンを押してコピー
+              <span className="font-medium text-text">送信キー（アクセストークン）</span>：「Messaging API設定」タブ →「チャネルアクセストークン（長期）」の「発行」ボタンを押してコピー
             </p>
           </div>
         </div>
@@ -117,13 +118,15 @@ export function LineSetupGuide({ onConnected }: Props) {
 
       {/* 入力フォーム */}
       <form onSubmit={handleSubmit} className="bg-surface border border-border rounded-2xl p-5 space-y-4">
-        <h3 className="font-bold">チャネル情報を入力</h3>
+        <h3 className="font-bold">接続情報を入力</h3>
 
         {error && <ErrorAlert message={error} />}
 
         <div>
           <label className="block text-sm font-medium mb-1.5">
-            チャネルID <span className="text-error">*</span>
+            接続番号（チャネルID）
+            <HelpTip>LINE Developersの「チャネル基本設定」タブに表示されている数字です。コピーしてそのまま貼り付けてください。</HelpTip>
+            <span className="text-error ml-0.5">*</span>
           </label>
           <input
             type="text"
@@ -137,7 +140,9 @@ export function LineSetupGuide({ onConnected }: Props) {
 
         <div>
           <label className="block text-sm font-medium mb-1.5">
-            チャネルシークレット <span className="text-error">*</span>
+            秘密キー（チャネルシークレット）
+            <HelpTip>「チャネル基本設定」タブの下部にある英数字の文字列です。salon-karteが本物のLINEからのメッセージかを確認するために使います。暗号化して安全に保存されます。</HelpTip>
+            <span className="text-error ml-0.5">*</span>
           </label>
           <input
             type="password"
@@ -152,7 +157,9 @@ export function LineSetupGuide({ onConnected }: Props) {
 
         <div>
           <label className="block text-sm font-medium mb-1.5">
-            チャネルアクセストークン <span className="text-error">*</span>
+            送信キー（チャネルアクセストークン）
+            <HelpTip>salon-karteがお客様にLINEメッセージを送るために必要なキーです。「Messaging API設定」タブで「発行」ボタンを押すと表示されます。暗号化して安全に保存されます。</HelpTip>
+            <span className="text-error ml-0.5">*</span>
           </label>
           <input
             type="password"

--- a/src/components/settings/line-status.tsx
+++ b/src/components/settings/line-status.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Toast, useToast } from "@/components/ui/toast";
 import { ToggleRow } from "@/components/ui/toggle-row";
+import { HelpTip } from "@/components/ui/help-tip";
 
 type LineConfig = {
   id: string;
@@ -89,20 +90,23 @@ export function LineStatus({ config, onUpdate, onDisconnect }: Props) {
 
         {error && <ErrorAlert message={error} />}
 
-        {/* Webhook URL */}
+        {/* Webhook URL（受信用アドレス） */}
         <div>
-          <label className="block text-sm font-medium mb-1.5">Webhook URL</label>
+          <label className="block text-sm font-medium mb-1.5">
+            受信用アドレス（Webhook URL）
+            <HelpTip>LINEからのメッセージ（友だち追加・ブロックなど）をsalon-karteが受け取るためのアドレスです。LINE側にこのアドレスを登録する必要があります。</HelpTip>
+          </label>
           <div className="text-xs text-text-light mb-2 space-y-1">
             <p>
               <a href="https://developers.line.biz/console/" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline font-medium">
-                LINE Developers Console
+                LINE Developers（開発者向け管理画面）
               </a>
               で以下を設定してください：
             </p>
             <ol className="list-decimal list-inside space-y-0.5 ml-1">
               <li>「Messaging API設定」タブを開く</li>
-              <li>「Webhook URL」に下のURLを貼り付けて「更新」</li>
-              <li>「検証」ボタンを押して「成功」と表示されることを確認</li>
+              <li>「Webhook URL」に下のアドレスを貼り付けて「更新」</li>
+              <li>「検証」ボタンを押して「成功」と出ればOK</li>
               <li>「Webhookの利用」をONにする</li>
             </ol>
           </div>

--- a/src/components/ui/help-tip.tsx
+++ b/src/components/ui/help-tip.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+/** ?アイコン → タップで説明を表示するヘルプ吹き出し */
+export function HelpTip({ children }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span className="relative inline-flex items-center ml-1">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-5 h-5 rounded-full bg-border/60 text-text-light text-[11px] font-bold inline-flex items-center justify-center hover:bg-border transition-colors"
+        aria-label="ヘルプ"
+      >
+        ?
+      </button>
+      {open && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+            aria-label="閉じる"
+          />
+          <div className="absolute left-0 top-7 z-50 w-64 bg-surface border border-border rounded-xl p-3 shadow-lg text-xs text-text-light leading-relaxed">
+            {children}
+          </div>
+        </>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
C. LINE設定の用語改善:
- 専門用語を排除（チャネルID→接続番号、チャネルシークレット→秘密キー等）
- Webhook URL→受信用アドレスに変更し、HelpTipで役割を説明
- よくあるトラブルFAQをaccordionで追加（通知が届かない/紐付け方法/接続番号の場所）
- 通数制限の説明もaccordion化して画面をすっきりに

D. HelpTipコンポーネント:
- ?アイコンタップで説明吹き出しを表示する汎用コンポーネント
- LINE設定の入力フォーム3箇所に配置
- 予約受付設定（同時予約数・受付締切・キャンセル締切）に配置
- Web予約設定（公開トグル・予約URL）に配置

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01FZBAGxXksL3os7k3SAV6Di