### PR TITLE
fix: GitHub Actions のラベル作成を Issue 作成の前に移動

### DIFF
--- a/.github/workflows/weekly-acquisition-review.yml
+++ b/.github/workflows/weekly-acquisition-review.yml
@@ -47,6 +47,13 @@ jobs:
             echo "report_path=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create labels if not exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "acquisition" --color "0E8A16" --description "集客関連" --force || true
+          gh label create "pdca-review" --color "5319E7" --description "PDCA週次レビュー" --force || true
+
       - name: Create GitHub Issue
         if: steps.report.outputs.report_path != ''
         env:
@@ -61,10 +68,3 @@ jobs:
             --title "📊 週次集客レビュー ${WEEK_START}〜${WEEK_END}" \
             --body "${BODY}" \
             --label "acquisition,pdca-review"
-
-      - name: Create labels if not exist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh label create "acquisition" --color "0E8A16" --description "集客関連" --force || true
-          gh label create "pdca-review" --color "5319E7" --description "PDCA週次レビュー" --force || true


### PR DESCRIPTION
ラベルが存在しない状態で gh issue create --label を実行するとエラーになるため、 ラベル作成ステップを先に実行するよう順序を修正。

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_017i71JxUuZKZmbNDKCPKXHc