### PR TITLE
fix: 新規登録の確認メールをResend経由に変更し到達率を改善

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,13 +2,11 @@
 
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
+import { useSearchParams } from "next/navigation";
 import { BrandLogo } from "@/components/ui/brand-logo";
 import { trackEvent } from "@/lib/analytics";
 
 function SignupForm() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const refCode = searchParams.get("ref") || "";
   const [email, setEmail] = useState("");
@@ -18,6 +16,8 @@ function SignupForm() {
   const [loading, setLoading] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
   const [agreed, setAgreed] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [resendSuccess, setResendSuccess] = useState(false);
 
   // ページ表示時に signup_start を送信
   useEffect(() => {
@@ -45,38 +45,64 @@ function SignupForm() {
 
     setLoading(true);
 
-    const supabase = createClient();
-    const { data, error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-        data: {
-          agreed_terms_at: new Date().toISOString(),
-          terms_version: "2026-03-01",
-        },
-      },
-    });
+    try {
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          password,
+          agreedTermsAt: new Date().toISOString(),
+          termsVersion: "2026-03-01",
+          refCode,
+        }),
+      });
 
-    if (error) {
-      console.error("サインアップエラー:", error);
-      setError(`登録に失敗しました: ${error.message}`);
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "登録に失敗しました");
+        setLoading(false);
+        return;
+      }
+
+      // サインアップ成功
+      trackEvent({ name: "signup_complete", params: { method: "email" } });
+
+      // メール確認が必要（通常フロー）
+      setEmailSent(true);
       setLoading(false);
-      return;
+    } catch (err) {
+      console.error("サインアップエラー:", err);
+      setError("ネットワークエラーが発生しました。もう一度お試しください。");
+      setLoading(false);
     }
+  };
 
-    // サインアップ成功
-    trackEvent({ name: "signup_complete", params: { method: "email" } });
+  const handleResendEmail = async () => {
+    setResending(true);
+    setResendSuccess(false);
+    setError("");
 
-    // If session exists immediately (email confirmation disabled), go to setup
-    if (data.session) {
-      router.push(refCode ? `/setup?ref=${encodeURIComponent(refCode)}` : "/setup");
-      return;
+    try {
+      const res = await fetch("/api/auth/resend-confirmation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "再送に失敗しました");
+      } else {
+        setResendSuccess(true);
+      }
+    } catch {
+      setError("ネットワークエラーが発生しました");
+    } finally {
+      setResending(false);
     }
-
-    // Email confirmation required
-    setEmailSent(true);
-    setLoading(false);
   };
 
   if (emailSent) {
@@ -95,9 +121,31 @@ function SignupForm() {
               <br />
               メール内のリンクをクリックして登録を完了してください。
             </p>
+            <div className="bg-background rounded-xl p-3">
+              <p className="text-xs text-text-light leading-relaxed">
+                メールが届かない場合は、迷惑メールフォルダもご確認ください。
+              </p>
+            </div>
+            {resendSuccess && (
+              <div className="bg-green-50 text-green-700 text-sm rounded-lg p-3">
+                確認メールを再送しました
+              </div>
+            )}
+            {error && (
+              <div className="bg-error/10 text-error text-sm rounded-lg p-3">
+                {error}
+              </div>
+            )}
+            <button
+              onClick={handleResendEmail}
+              disabled={resending}
+              className="text-sm text-accent font-medium hover:underline disabled:opacity-50 min-h-[44px]"
+            >
+              {resending ? "送信中..." : "確認メールを再送する"}
+            </button>
             <Link
               href="/login"
-              className="block text-sm text-accent font-medium hover:underline mt-4"
+              className="block text-sm text-text-light font-medium hover:underline mt-2"
             >
               ログインページに戻る
             </Link>

--- a/src/app/api/auth/resend-confirmation/route.ts
+++ b/src/app/api/auth/resend-confirmation/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getResendClient, getFromAddress } from "@/lib/email/client";
+import { buildRegistrationConfirmationEmail } from "@/lib/email/templates";
+
+export async function POST(request: Request) {
+  try {
+    const { email } = await request.json();
+
+    if (!email) {
+      return NextResponse.json(
+        { error: "メールアドレスは必須です" },
+        { status: 400 }
+      );
+    }
+
+    const admin = createAdminClient();
+
+    // ユーザーが存在し、未確認であることを確認
+    const { data: users, error: listError } =
+      await admin.auth.admin.listUsers();
+    if (listError) {
+      console.error("ユーザー一覧取得エラー:", listError);
+      return NextResponse.json(
+        { error: "サーバーエラーが発生しました" },
+        { status: 500 }
+      );
+    }
+
+    const user = users.users.find((u) => u.email === email);
+    if (!user) {
+      // セキュリティ: ユーザーの存在を漏らさない
+      return NextResponse.json({ success: true });
+    }
+
+    if (user.email_confirmed_at) {
+      // 既に確認済み
+      return NextResponse.json({ success: true, alreadyConfirmed: true });
+    }
+
+    // 新しい確認リンクを生成
+    const { data: linkData, error: linkError } =
+      await admin.auth.admin.generateLink({
+        type: "signup",
+        email,
+        password: "", // 既存ユーザーの場合はパスワード不要（リンク再生成のみ）
+      });
+
+    if (linkError) {
+      console.error("確認リンク再生成エラー:", linkError);
+      // "already registered" は正常ケース（既にユーザーがいるため）
+      // magiclink タイプで再送を試行
+      const { data: magicData, error: magicError } =
+        await admin.auth.admin.generateLink({
+          type: "magiclink",
+          email,
+        });
+
+      if (magicError) {
+        console.error("マジックリンク生成エラー:", magicError);
+        return NextResponse.json(
+          { error: "確認メールの再送に失敗しました" },
+          { status: 500 }
+        );
+      }
+
+      // magiclink の場合もメール確認として使える
+      const baseUrl =
+        process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+      if (!baseUrl) {
+        return NextResponse.json(
+          { error: "サーバー設定エラーが発生しました" },
+          { status: 500 }
+        );
+      }
+
+      const confirmUrl = new URL("/auth/callback", baseUrl);
+      confirmUrl.searchParams.set(
+        "token_hash",
+        magicData.properties.hashed_token
+      );
+      confirmUrl.searchParams.set("type", "magiclink");
+
+      const resend = getResendClient();
+      if (resend) {
+        const { subject, html } = buildRegistrationConfirmationEmail({
+          confirmUrl: confirmUrl.toString(),
+        });
+
+        await resend.emails.send({
+          from: getFromAddress(),
+          to: email,
+          subject,
+          html,
+        });
+      }
+
+      return NextResponse.json({ success: true });
+    }
+
+    // 確認URLを組み立て
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+    if (!baseUrl) {
+      return NextResponse.json(
+        { error: "サーバー設定エラーが発生しました" },
+        { status: 500 }
+      );
+    }
+
+    const confirmUrl = new URL("/auth/callback", baseUrl);
+    confirmUrl.searchParams.set(
+      "token_hash",
+      linkData.properties.hashed_token
+    );
+    confirmUrl.searchParams.set("type", "signup");
+
+    // Resend で送信
+    const resend = getResendClient();
+    if (resend) {
+      const { subject, html } = buildRegistrationConfirmationEmail({
+        confirmUrl: confirmUrl.toString(),
+      });
+
+      const { error: emailError } = await resend.emails.send({
+        from: getFromAddress(),
+        to: email,
+        subject,
+        html,
+      });
+
+      if (emailError) {
+        console.error("確認メール再送エラー:", emailError);
+        return NextResponse.json(
+          { error: "メールの送信に失敗しました" },
+          { status: 500 }
+        );
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("確認メール再送処理エラー:", err);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getResendClient, getFromAddress } from "@/lib/email/client";
+import { buildRegistrationConfirmationEmail } from "@/lib/email/templates";
+
+export async function POST(request: Request) {
+  try {
+    const { email, password, agreedTermsAt, termsVersion, refCode } =
+      await request.json();
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: "メールアドレスとパスワードは必須です" },
+        { status: 400 }
+      );
+    }
+
+    if (password.length < 8) {
+      return NextResponse.json(
+        { error: "パスワードは8文字以上で入力してください" },
+        { status: 400 }
+      );
+    }
+
+    const admin = createAdminClient();
+
+    // Admin API で確認リンクを生成（メール送信はしない）
+    const { data: linkData, error: linkError } =
+      await admin.auth.admin.generateLink({
+        type: "signup",
+        email,
+        password,
+        options: {
+          data: {
+            agreed_terms_at: agreedTermsAt,
+            terms_version: termsVersion,
+          },
+        },
+      });
+
+    if (linkError) {
+      console.error("サインアップリンク生成エラー:", linkError);
+
+      // よくあるエラーを日本語化
+      if (linkError.message?.includes("already registered")) {
+        return NextResponse.json(
+          { error: "このメールアドレスは既に登録されています" },
+          { status: 409 }
+        );
+      }
+
+      return NextResponse.json(
+        { error: `登録に失敗しました: ${linkError.message}` },
+        { status: 400 }
+      );
+    }
+
+    // 確認URLを組み立て（Supabase が返す hashed_token を使う）
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+    if (!baseUrl) {
+      console.error("NEXT_PUBLIC_APP_URL / NEXT_PUBLIC_BASE_URL が未設定です");
+      return NextResponse.json(
+        { error: "サーバー設定エラーが発生しました" },
+        { status: 500 }
+      );
+    }
+
+    const confirmUrl = new URL("/auth/callback", baseUrl);
+    confirmUrl.searchParams.set(
+      "token_hash",
+      linkData.properties.hashed_token
+    );
+    confirmUrl.searchParams.set("type", "signup");
+    // 紹介コードがあれば callback 後のリダイレクト先に含める
+    if (refCode) {
+      confirmUrl.searchParams.set(
+        "next",
+        `/setup?ref=${encodeURIComponent(refCode)}`
+      );
+    }
+
+    // Resend でブランド付き確認メールを送信
+    const resend = getResendClient();
+    if (resend) {
+      const { subject, html } = buildRegistrationConfirmationEmail({
+        confirmUrl: confirmUrl.toString(),
+      });
+
+      const { error: emailError } = await resend.emails.send({
+        from: getFromAddress(),
+        to: email,
+        subject,
+        html,
+      });
+
+      if (emailError) {
+        console.error("確認メール送信エラー:", emailError);
+        // メール送信失敗してもユーザー作成は成功しているため、エラーにはしない
+        // ただし再送できるようにフラグを返す
+        return NextResponse.json({
+          success: true,
+          emailSent: false,
+          message:
+            "アカウントは作成されましたが、確認メールの送信に失敗しました。再送をお試しください。",
+        });
+      }
+    } else {
+      console.warn("RESEND_API_KEY 未設定のため確認メールをスキップしました");
+    }
+
+    return NextResponse.json({ success: true, emailSent: true });
+  } catch (err) {
+    console.error("サインアップ処理エラー:", err);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -354,6 +354,49 @@ export function buildCustomerChangeConfirmationEmail(info: CustomerChangeConfirm
   };
 }
 
+type RegistrationConfirmationInfo = {
+  confirmUrl: string;
+};
+
+// 新規登録: メールアドレス確認メール
+export function buildRegistrationConfirmationEmail(info: RegistrationConfirmationInfo): {
+  subject: string;
+  html: string;
+} {
+  const body = `
+<tr><td style="padding:32px 24px 0;text-align:center;">
+  <h1 style="margin:0;font-size:20px;color:#333;">サロンカルテへようこそ</h1>
+</td></tr>
+<tr><td style="padding:24px;">
+  <p style="margin:0 0 16px;font-size:14px;color:#333;line-height:1.6;">
+    アカウント登録ありがとうございます。<br>
+    以下のボタンをクリックしてメールアドレスを確認し、登録を完了してください。
+  </p>
+  <div style="margin:24px 0;text-align:center;">
+    <a href="${info.confirmUrl}" style="display:inline-block;background:#c4956a;color:#ffffff;font-size:14px;font-weight:bold;padding:14px 40px;border-radius:12px;text-decoration:none;">
+      メールアドレスを確認する
+    </a>
+  </div>
+  <p style="margin:0 0 16px;font-size:13px;color:#888;line-height:1.6;">
+    ボタンが押せない場合は、以下のURLをブラウザにコピー＆ペーストしてください:
+  </p>
+  <p style="margin:0 0 24px;font-size:12px;color:#888;word-break:break-all;">
+    ${info.confirmUrl}
+  </p>
+  <div style="border-top:1px solid #eee;padding-top:16px;">
+    <p style="margin:0;font-size:12px;color:#999;line-height:1.6;">
+      このリンクは24時間有効です。<br>
+      心当たりのない場合は、このメールを無視してください。
+    </p>
+  </div>
+</td></tr>`;
+
+  return {
+    subject: "【サロンカルテ】メールアドレスの確認",
+    html: wrapHtml(body),
+  };
+}
+
 type OwnerChangeNotificationInfo = {
   customerName: string;
   oldDate: string;


### PR DESCRIPTION
Supabase Authのビルトインメール（共有SMTP・低到達率）から
Resend経由のブランド付きメール送信に切り替え。

- サインアップAPIルート新設（Admin API + Resend）
- 確認メール再送機能を追加
- サロンカルテブランドの確認メールテンプレート追加
- サインアップページをAPI呼び出しに変更

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01YbvKozk9QY6f6KZYDnKBHp