### PR TITLE
fix: LINE前日リマインドのcronハンドラをGETに修正

### DIFF
--- a/src/app/api/cron/__tests__/line-reminders.test.ts
+++ b/src/app/api/cron/__tests__/line-reminders.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import * as route from "@/app/api/cron/line-reminders/route";
+
+// Vercel Cron は GET でしか呼び出さない。
+// 過去に POST のみで実装して空振りしていた障害があるため、ハンドラ形状を固定する。
+describe("cron/line-reminders route", () => {
+  it("GET ハンドラがエクスポートされている", () => {
+    expect(typeof (route as Record<string, unknown>).GET).toBe("function");
+  });
+
+  it("POST ハンドラは存在しない（Vercel Cron は GET）", () => {
+    expect((route as Record<string, unknown>).POST).toBeUndefined();
+  });
+});

--- a/src/app/api/cron/line-reminders/route.ts
+++ b/src/app/api/cron/line-reminders/route.ts
@@ -7,9 +7,10 @@ import { buildReminderMessage } from "@/lib/line/messages";
 import { getResendClient, getFromAddress } from "@/lib/email/client";
 import { buildCustomerReminderEmail } from "@/lib/email/templates";
 
-// POST: 前日リマインド（Vercel Cron Job: 毎日 12:00 UTC = 21:00 JST）
+// GET: 前日リマインド（Vercel Cron Job: 毎日 12:00 UTC = 21:00 JST）
 // LINE + メール の両チャネルで送信
-export async function POST(request: Request) {
+// Vercel Cron は GET で呼び出す仕様。POST にすると 405 で空振りし続けるので注意
+export async function GET(request: Request) {
   // CRON_SECRET検証（未設定時はリクエストを拒否）
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {


### PR DESCRIPTION
## 背景

SEIサロンのオーナーから「お客様に前日リマインドLINEが届いていない」との連絡を受けて調査したところ、**本番のLINE前日リマインドが 2026-03-06 のリリース以降、1件も送信されていなかった**ことが判明。

### 根本原因

`vercel.json` で登録した cron は Vercel の仕様により **HTTP GET** で叩かれるが、`/api/cron/line-reminders/route.ts` は `POST` しかエクスポートしていなかった。Next.js の route handler は対応するメソッドが無いと `405 Method Not Allowed` を返すため、毎日21時のスケジュールは **ずっと空振り** していた。

### データによる裏付け（本番参照のみ）

| 確認項目 | 結果 |
|---|---|
| SEIサロンのLINE設定 | `is_active=true` / `reminder_enabled=true` / `confirmation_enabled=true` — **設定は正常** |
| SEIの顧客LINE紐付け | アクティブ紐付け 14名 — **送る相手は存在** |
| SEIの送信ログ | `confirmation` 6件のみ。**`reminder` は 0件** |
| 全サロンの reminder ログ | 直近は 2026-02-22（テスト時）で打ち止め — **本番cronがずっと止まっていた** |

`confirmation`（即時通知）は届いていたため、LINE APIトークンや暗号化・Webhookは正常。**cronのHTTPメソッド違いだけが原因**。

## 変更内容

- `src/app/api/cron/line-reminders/route.ts`: `export async function POST` → `GET` に変更（`CRON_SECRET` Bearer認証のロジックはそのまま維持）
- 同ファイル冒頭に「Vercel Cron は GET で叩く。POST にしない」コメントを追加
- `src/app/api/cron/__tests__/line-reminders.test.ts`（新規）: GETがエクスポート済・POSTが未定義であることを検証する再発防止テスト

## 送信ロジックの安全性

過去日のリマインド再送のリスクはありません。送信対象は以下でピンポイント絞り込み：

```ts
.eq("appointment_date", tomorrowStr)  // 明日1日分のみ
.eq("status", "scheduled")
```

過去日・`completed`・`cancelled` は物理的にヒットしません。

## 検証方針（安全案）

- **Run now は実行しない**（日中に押すと顧客に不自然な時刻でLINEが届くため）
- マージ後、**翌21時(JST) の自動実行** を待つ
- 翌朝、以下で確認:
  ```sql
  SELECT salon_id, status, COUNT(*), MIN(created_at), MAX(created_at)
  FROM line_message_logs
  WHERE message_type = 'reminder' AND created_at > CURRENT_DATE
  GROUP BY salon_id, status;
  ```
- SEIサロン（`17ed3123-244b-43ab-936f-74c422982fb3`）で sent 件数が出ていればOK → オーナーへ連絡

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npm test` パス（117テスト・追加2件含む）
- [x] `npm run build` パス
- [x] `python3 scripts/check-select-columns.sh` パス
- [ ] マージ翌朝、`line_message_logs` で reminder の sent 件数を確認
- [ ] SEIサロンのお客様分にreminderが届いていることを確認

## 関連の残課題（別PR予定）

- 予約変更・キャンセル時の LINE 通知は現状未実装（メールのみ）。別PRで対応予定。

https://claude.ai/code/session_01Xr7aXuFGivUuNwUQ9ADwuk